### PR TITLE
[feat] 프로필 사진 변경 기능

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -32,6 +32,7 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.rest-assured:rest-assured:4.5.1'
 
     // S3
     implementation 'com.amazonaws:aws-java-sdk-s3:1.12.518'

--- a/backend/src/main/java/codesquard/app/api/image/ImageService.java
+++ b/backend/src/main/java/codesquard/app/api/image/ImageService.java
@@ -36,4 +36,9 @@ public class ImageService {
 		}
 		return urls;
 	}
+
+	@Transactional
+	public void deleteImage(String fileName) {
+		imageUploader.deleteImage(fileName);
+	}
 }

--- a/backend/src/main/java/codesquard/app/api/image/ImageUploader.java
+++ b/backend/src/main/java/codesquard/app/api/image/ImageUploader.java
@@ -36,4 +36,8 @@ public class ImageUploader {
 	private String getObjectUri(String fileName) {
 		return URLDecoder.decode(amazonS3Client.getUrl(bucket, fileName).toString(), StandardCharsets.UTF_8);
 	}
+
+	public void deleteImage(String fileName) {
+		amazonS3Client.deleteObject(bucket, fileName);
+	}
 }

--- a/backend/src/main/java/codesquard/app/api/member/MemberController.java
+++ b/backend/src/main/java/codesquard/app/api/member/MemberController.java
@@ -24,6 +24,6 @@ public class MemberController {
 	public ResponseEntity<ApiResponse<Void>> modifyProfileImage(@RequestPart MultipartFile updateImageFile,
 		@PathVariable String loginId) {
 		memberService.modifyProfileImage(loginId, updateImageFile);
-		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.ok("수정되었습니다.", null));
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.ok("프로필 사진이 수정되었습니다.", null));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/member/MemberController.java
+++ b/backend/src/main/java/codesquard/app/api/member/MemberController.java
@@ -1,0 +1,29 @@
+package codesquard.app.api.member;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import codesquard.app.api.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/members")
+@RequiredArgsConstructor
+public class MemberController {
+
+	private final MemberService memberService;
+
+	@PutMapping(value = "/{loginId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<ApiResponse<Void>> modifyProfileImage(@RequestPart MultipartFile updateImageFile,
+		@PathVariable String loginId) {
+		memberService.modifyProfileImage(loginId, updateImageFile);
+		return ResponseEntity.status(HttpStatus.OK).body(ApiResponse.ok("수정되었습니다.", null));
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/member/MemberService.java
+++ b/backend/src/main/java/codesquard/app/api/member/MemberService.java
@@ -1,0 +1,28 @@
+package codesquard.app.api.member;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.exception.RestApiException;
+import codesquard.app.api.image.ImageService;
+import codesquard.app.domain.member.Member;
+import codesquard.app.domain.member.MemberRepository;
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class MemberService {
+
+	private final MemberRepository memberRepository;
+	private final ImageService imageService;
+
+	@Transactional
+	public void modifyProfileImage(String loginId, MultipartFile updateImageFile) {
+		Member member = memberRepository.findMemberByLoginId(loginId)
+			.orElseThrow(() -> new RestApiException(MemberErrorCode.NOT_FOUND_MEMBER));
+		imageService.deleteImage(member.getAvatarUrl());
+		member.setAvatarUrl(imageService.uploadImage(updateImageFile));
+	}
+}

--- a/backend/src/main/java/codesquard/app/domain/image/ImageFile.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageFile.java
@@ -90,7 +90,7 @@ public class ImageFile {
 			log.info("ContentType : {}", contentType);
 
 			for (ImageContentType imageContentType : ImageContentType.values()) {
-				if (imageContentType.getContentType().equals(contentType)) {
+				if (imageContentType.getContentType().equals(contentType.toLowerCase())) {
 					return imageContentType.getContentType();
 				}
 			}

--- a/backend/src/main/java/codesquard/app/domain/member/Member.java
+++ b/backend/src/main/java/codesquard/app/domain/member/Member.java
@@ -24,6 +24,7 @@ import lombok.ToString;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Entity
 public class Member {
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id; // 회원 등록번호
@@ -64,5 +65,9 @@ public class Member {
 		claims.put("email", email);
 		claims.put("loginId", loginId);
 		return claims;
+	}
+
+	public void setAvatarUrl(String avatarUrl) {
+		this.avatarUrl = avatarUrl;
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/item/unit/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/unit/ItemServiceTest.java
@@ -1,4 +1,4 @@
-package codesquard.app.api.item;
+package codesquard.app.api.item.unit;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -20,6 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
 import codesquard.app.api.image.ImageUploader;
+import codesquard.app.api.item.ItemRegisterRequest;
+import codesquard.app.api.item.ItemService;
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.member.Member;
 

--- a/backend/src/test/java/codesquard/app/api/member/MemberServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/member/MemberServiceTest.java
@@ -1,0 +1,62 @@
+package codesquard.app.api.member;
+
+import static io.restassured.RestAssured.given;
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.boot.test.context.SpringBootTest.*;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import codesquard.app.api.image.ImageUploader;
+import codesquard.app.domain.jwt.JwtProvider;
+import codesquard.app.domain.member.Member;
+import codesquard.support.SupportRepository;
+
+@SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
+class MemberServiceTest {
+
+	@Autowired
+	private JwtProvider jwtProvider;
+	@Autowired
+	private SupportRepository repository;
+	@MockBean
+	private ImageUploader imageUploader;
+
+	@Test
+	@DisplayName("사용자의 프로필 사진 변경에 성공한다.")
+	void modifyProfileImage() throws IOException {
+
+		// given
+		given(imageUploader.uploadImageToS3(any(), anyString())).willReturn("url");
+		willDoNothing().given(imageUploader).deleteImage(anyString());
+		repository.save(Member.create("url", "email", "pie"));
+
+		var request = given().log().all()
+			.header(HttpHeaders.AUTHORIZATION,
+				"Bearer " + jwtProvider.createJwtBasedOnMember(new Member(1L)).getAccessToken())
+			.contentType(MediaType.MULTIPART_FORM_DATA_VALUE)
+			.multiPart("updateImageFile",
+				File.createTempFile("test-image", ".png"),
+				MediaType.IMAGE_PNG_VALUE);
+
+		// when
+		var response = request
+			.when()
+			.put("/api/members/pie")
+			.then().log().all()
+			.extract();
+
+		// then
+		assertThat(response.statusCode()).isEqualTo(200);
+	}
+}

--- a/backend/src/test/java/codesquard/app/api/member/unit/MemberServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/member/unit/MemberServiceTest.java
@@ -1,0 +1,54 @@
+package codesquard.app.api.member.unit;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.BDDMockito.*;
+
+import java.nio.charset.StandardCharsets;
+
+import javax.persistence.EntityManager;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.transaction.annotation.Transactional;
+
+import codesquard.app.api.image.ImageUploader;
+import codesquard.app.api.member.MemberService;
+import codesquard.app.domain.member.Member;
+
+@SpringBootTest
+class MemberServiceTest {
+
+	@Autowired
+	private MemberService memberService;
+	@Autowired
+	private EntityManager em;
+	@MockBean
+	private ImageUploader imageUploader;
+
+	@Test
+	@DisplayName("프로필 사진 변경에 성공한다.")
+	@Transactional
+	void modifyProfileUrl() {
+
+		// given
+		given(imageUploader.uploadImageToS3(any(), anyString())).willReturn("test-image.png");
+		em.persist(Member.create("123123", "123@123", "pieeeee"));
+		MockMultipartFile mockMultipartFile = new MockMultipartFile(
+			"test-image",
+			"test-image.png",
+			MediaType.IMAGE_PNG_VALUE,
+			"image-content".getBytes(StandardCharsets.UTF_8));
+
+		// when
+		memberService.modifyProfileImage("pieeeee", mockMultipartFile);
+		Member member = em.find(Member.class, 1L);
+
+		// then
+		assertThat(member.getAvatarUrl()).isEqualTo(mockMultipartFile.getOriginalFilename());
+	}
+}

--- a/backend/src/test/java/codesquard/support/SupportRepository.java
+++ b/backend/src/test/java/codesquard/support/SupportRepository.java
@@ -1,0 +1,22 @@
+package codesquard.support;
+
+import javax.persistence.EntityManager;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@Transactional
+public class SupportRepository {
+
+	@Autowired
+	private EntityManager em;
+
+	public <T> T save(T entity) {
+		em.persist(entity);
+		em.flush();
+		em.clear();
+		return entity;
+	}
+}


### PR DESCRIPTION
## 구현한 것
- 프로필 사진 변경 기능
- 기존 이미지 삭제
- 테스트 코드 작성

## 어려웠던 점
- 인수 테스트를 처음 작성해봐서 어려움을 겪었습니다

## 고민점
- 인수 테스트 내에서 Member 객체를 생성하면 DB에 저장이 되지 않아 테스트할 때 회원을 찾을 수 없다는 에러가 자꾸 나서 따로 회원을 저장하는 클래스를 만들고 인수 테스트 내에 `@Autowired`를 했더니 문제 없이 테스트를 통과했는데 이유를 모르겠어서 고민이 됐습니다.
- `MemberSerivce`에서 `ImageService`를 통해 `ImageUploader`에게 사진을 삭제하게끔 구현해놨는데,
 `MemberService`에서 `ImageUploader` 클래스를 필드로 두고 직접 접근하면 되는지, 안되는지에 대한 고민을 했습니다. 
 결론적으로는 `ImageUploader` 클래스는 `ImageService`의 영역인거 같아 기존 코드를 그대로 유지하였습니다.
