### PR TITLE
[feat] 회원가입 설계 변경으로 인한 코드 수정

### DIFF
--- a/backend/src/main/java/codesquard/app/api/oauth/request/OauthSignUpRequest.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/request/OauthSignUpRequest.java
@@ -2,8 +2,12 @@ package codesquard.app.api.oauth.request;
 
 import static codesquard.app.config.ValidationGroups.*;
 
+import java.util.List;
+
 import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.membertown.MemberTown;
@@ -18,28 +22,30 @@ public class OauthSignUpRequest {
 	@NotBlank(message = "로그인 아이디는 필수 정보입니다.", groups = NotBlankGroup.class)
 	@Pattern(regexp = "^[a-zA-Z0-9]{2,12}$", message = "아이디는 띄어쓰기 없이 영문, 숫자로 구성되며 2~12글자로 구성되어야 합니다.", groups = PatternGroup.class)
 	private String loginId;
-	@NotBlank(message = "동네 이름은 필수 정보입니다.", groups = NotBlankGroup.class)
-	private String addressName;
+	@NotNull(message = "주소 이름은 공백이면 안됩니다.", groups = NotNullGroup.class)
+	@Size(min = 1, max = 2, message = "동네 주소는 최소 1개에서 최대 2개까지 추가할 수 있습니다.", groups = SizeGroup.class)
+	private List<@NotBlank(message = "주소 이름은 공백이면 안됩니다.", groups = NotBlankGroup.class) String> addressNames;
 
-	private OauthSignUpRequest(String loginId, String addressName) {
+	private OauthSignUpRequest(String loginId, List<String> addressNames) {
 		this.loginId = loginId;
-		this.addressName = addressName;
+		this.addressNames = addressNames;
 	}
 
-	public static OauthSignUpRequest create(String loginId, String addrName) {
-		return new OauthSignUpRequest(loginId, addrName);
+	public static OauthSignUpRequest create(String loginId, List<String> addressNames) {
+		return new OauthSignUpRequest(loginId, addressNames);
 	}
 
 	public Member toEntity(String avatarUrl, String email) {
 		Member member = Member.create(avatarUrl, email, loginId);
-		MemberTown town = MemberTown.create(addressName);
-		member.addMemberTown(town);
+		addressNames.stream()
+			.map(MemberTown::create)
+			.forEach(member::addMemberTown);
 		return member;
 	}
 
 	@Override
 	public String toString() {
 		return String.format("%s, %s(loginId=%s, addressName=%s)", "회원가입 요청", this.getClass().getSimpleName(), loginId,
-			addressName);
+			addressNames);
 	}
 }

--- a/backend/src/main/java/codesquard/app/config/ValidationGroups.java
+++ b/backend/src/main/java/codesquard/app/config/ValidationGroups.java
@@ -2,6 +2,10 @@ package codesquard.app.config;
 
 public class ValidationGroups {
 
+	public interface NotNullGroup {
+
+	}
+
 	public interface NotBlankGroup {
 	}
 

--- a/backend/src/main/java/codesquard/app/config/ValidationGroups.java
+++ b/backend/src/main/java/codesquard/app/config/ValidationGroups.java
@@ -3,7 +3,6 @@ package codesquard.app.config;
 public class ValidationGroups {
 
 	public interface NotNullGroup {
-
 	}
 
 	public interface NotBlankGroup {

--- a/backend/src/main/java/codesquard/app/config/ValidationSequence.java
+++ b/backend/src/main/java/codesquard/app/config/ValidationSequence.java
@@ -2,7 +2,10 @@ package codesquard.app.config;
 
 import javax.validation.GroupSequence;
 
-@GroupSequence({ValidationGroups.NotBlankGroup.class, ValidationGroups.PatternGroup.class,
+@GroupSequence({
+	ValidationGroups.NotNullGroup.class,
+	ValidationGroups.NotBlankGroup.class,
+	ValidationGroups.PatternGroup.class,
 	ValidationGroups.SizeGroup.class})
 public interface ValidationSequence {
 }

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
@@ -6,6 +6,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.LocalDateTime;
+import java.util.List;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.mock.web.MockMultipartFile;
@@ -24,7 +25,7 @@ import codesquard.app.domain.member.Member;
 public class OauthFixedFactory {
 
 	private static final String LOGIN_ID = "23Yong";
-	private static final String ADDR_NAME = "가락 1동";
+	private static final List<String> ADDRESS_NAMES = List.of("가락 1동");
 	private static final String ACCESS_TOKEN = "eyJhbGciOiJIUzI1NiJ9.eyJsb2dpbklkIjoiMjNZb25nIiwiZW1haWwiOiIyM1lvbm"
 		+ "dAZ21haWwuY29tIiwibWVtYmVySWQiOjEsImV4cCI6MTY3MjQ5OTEwMH0.7w2MKSLPVEr6wo7B-C6drNA3eETikpnYi2M1V8c9erY";
 	private static final String SCOPE = "scopeValue";
@@ -33,11 +34,11 @@ public class OauthFixedFactory {
 	private static final String AVATAR_URL = "avatarUrlValue";
 
 	public static OauthSignUpRequest createFixedOauthSignUpRequest() {
-		return OauthSignUpRequest.create(LOGIN_ID, ADDR_NAME);
+		return OauthSignUpRequest.create(LOGIN_ID, ADDRESS_NAMES);
 	}
 
-	public static OauthSignUpRequest createFixedOauthSignUpRequest(String loginId, String addrName) {
-		return OauthSignUpRequest.create(loginId, addrName);
+	public static OauthSignUpRequest createFixedOauthSignUpRequest(String loginId, List<String> addressNames) {
+		return OauthSignUpRequest.create(loginId, addressNames);
 	}
 
 	public static OauthAccessTokenResponse createFixedOauthAccessTokenResponse() {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -6,6 +6,8 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.stream.Stream;
 
 import org.apache.http.HttpHeaders;
@@ -82,7 +84,8 @@ class OauthRestControllerTest extends ControllerTestSupport {
 	public void signupWhenInvalidLoginId(String loginId) throws Exception {
 		// given
 		MockMultipartFile mockProfile = createFixedProfile();
-		MockMultipartFile mockSignupData = createFixedSignUpData(createFixedOauthSignUpRequest(loginId, "가락 1동"));
+		MockMultipartFile mockSignupData = createFixedSignUpData(
+			createFixedOauthSignUpRequest(loginId, List.of("가락 1동")));
 
 		// when & then
 		mockMvc.perform(multipart("/api/auth/naver/signup")
@@ -102,8 +105,10 @@ class OauthRestControllerTest extends ControllerTestSupport {
 	@ParameterizedTest
 	public void signupWhenInvalidAddrName(String addrName) throws Exception {
 		// given
+		List<String> addressNames = new ArrayList<>();
+		addressNames.add(addrName);
 		MockMultipartFile mockProfile = createFixedProfile();
-		MockMultipartFile mockSignupData = createFixedSignUpData(createFixedOauthSignUpRequest("23Yong", addrName));
+		MockMultipartFile mockSignupData = createFixedSignUpData(createFixedOauthSignUpRequest("23Yong", addressNames));
 
 		// when & then
 		mockMvc.perform(multipart("/api/auth/naver/signup")
@@ -113,9 +118,9 @@ class OauthRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("statusCode").value(Matchers.equalTo(400)))
 			.andExpect(jsonPath("message").value(Matchers.equalTo("유효하지 않은 입력형식입니다.")))
-			.andExpect(jsonPath("data[0].field").value(Matchers.equalTo("addressName")))
+			.andExpect(jsonPath("data[0].field").value(Matchers.equalTo("addressNames[0]")))
 			.andExpect(jsonPath("data[0].defaultMessage").value(
-				Matchers.equalTo("동네 이름은 필수 정보입니다.")));
+				Matchers.equalTo("주소 이름은 공백이면 안됩니다.")));
 	}
 
 	@DisplayName("로그아웃을 요청한다")


### PR DESCRIPTION
## 구현한 것

- 회원가입에서 동네 주소를 하나의 문자열이 아닌 리스트 형식으로 받기로 변경

### 기존 설계 
<img width="867" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/babe6492-efff-4ae9-9720-195ffde45631">

### 변경된 설계
- addressName 프로퍼티가 addressNames로 이름이 변경되고 타입이 리스트 타입으로 변경되었습니다.

<img width="862" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/7f85ef77-5396-4e6e-88f2-a8d843b724c2">

