### PR TITLE
[fix] 액세스 토큰 갱신 서비스 응답 형식 변경

### DIFF
--- a/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
@@ -105,7 +105,7 @@ public class OauthService {
 		// key: "RT:" + email, value : 리프레쉬 토큰값
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 
 		return OauthLoginResponse.create(jwt, OauthLoginMemberResponse.from(member));

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthJwtResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthJwtResponse.java
@@ -1,0 +1,20 @@
+package codesquard.app.api.oauth.response;
+
+import codesquard.app.domain.jwt.Jwt;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OauthJwtResponse {
+	private String accessToken;
+
+	private OauthJwtResponse(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public static OauthJwtResponse create(Jwt jwt) {
+		return new OauthJwtResponse(jwt.getAccessToken());
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
@@ -8,14 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OauthRefreshResponse {
-	private Jwt jwt;
+	private OauthJwtResponse jwt;
 
-	private OauthRefreshResponse(Jwt jwt) {
+	private OauthRefreshResponse(OauthJwtResponse jwt) {
 		this.jwt = jwt;
 	}
 
 	public static OauthRefreshResponse create(Jwt jwt) {
-		return new OauthRefreshResponse(jwt);
+		return new OauthRefreshResponse(OauthJwtResponse.create(jwt));
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
+++ b/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
@@ -34,13 +34,7 @@ public class Jwt {
 		return new Jwt(accessToken, refreshToken, expireDateAccessToken, expireDateRefreshToken);
 	}
 
-	@JsonIgnore
-	public long getExpireDateAccessTokenTime() {
-		return expireDateAccessToken.getTime();
-	}
-
-	@JsonIgnore
-	public long getExpireDateRefreshTokenTime() {
+	public long convertExpireDateRefreshTokenTimeWithLong() {
 		return expireDateRefreshToken.getTime();
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
+++ b/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
@@ -13,7 +13,9 @@ public class Jwt {
 
 	private String accessToken;
 	private String refreshToken;
+	@JsonIgnore
 	private Date expireDateAccessToken;
+	@JsonIgnore
 	private Date expireDateRefreshToken;
 
 	private Jwt() {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -171,8 +171,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("statusCode").value(Matchers.equalTo(200)))
 			.andExpect(jsonPath("message").value(Matchers.equalTo("액세스 토큰 갱신에 성공하였습니다.")))
-			.andExpect(jsonPath("data.jwt.accessToken").isNotEmpty())
-			.andExpect(jsonPath("data.jwt.refreshToken").isNotEmpty());
+			.andExpect(jsonPath("data.jwt.accessToken").isNotEmpty());
 	}
 
 	private static Stream<Arguments> provideInvalidLoginId() {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -267,9 +267,8 @@ class OauthServiceTest extends IntegrationTestSupport {
 		// then
 		SoftAssertions.assertSoftly(softAssertions -> {
 			softAssertions.assertThat(response)
-				.extracting("jwt.accessToken", "jwt.refreshToken")
-				.contains(createExpectedAccessTokenBy(jwtProvider, member, now),
-					createExpectedRefreshTokenBy(jwtProvider, member, now));
+				.extracting("jwt.accessToken")
+				.isEqualTo(createExpectedAccessTokenBy(jwtProvider, member, now));
 			softAssertions.assertAll();
 		});
 	}

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -255,7 +255,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 		memberRepository.save(member);
 
@@ -284,7 +284,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 		memberRepository.save(member);
 


### PR DESCRIPTION
## 구현한 것

- 기존 refreshToken이 응답되는 것을 안나오도록 변경하였습니다.

## 실행 결과
- 다음 결과는 액세스 토큰 갱신 서비스를 요청한 결과입니다.
- 다음 결과와 같이 refreshToken이 응답되지 않은 것을 볼 수 있습니다.

<img width="860" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/4f32788f-fe30-480f-9cb3-ddd80c417798">
