### PR TITLE
[fix] 이중 회원가입 검증문 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
@@ -9,7 +9,8 @@ public enum OauthErrorCode implements ErrorCode {
 	WRONG_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, "잘못된 인가 코드입니다."),
 	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
 	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "provider를 찾을 수 없습니다."),
-	FAIL_LOGIN(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다.");
+	FAIL_LOGIN(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다."),
+	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
@@ -138,8 +138,10 @@ public class OauthService {
 		jwtProvider.validateToken(refreshToken);
 		log.debug("refreshToken is valid token : {}", refreshToken);
 
-		String email = findEmailByRefreshToken(refreshToken);
-		Member member = memberRepository.findMemberByEmail(email)
+		String emailAndLoginId = findEmailByRefreshToken(refreshToken);
+		String email = emailAndLoginId.split("-")[0];
+		String loginId = emailAndLoginId.split("-")[1];
+		Member member = memberRepository.findMemberByLoginIdAndEmail(loginId, email)
 			.orElseThrow(() -> new RestApiException(MemberErrorCode.NOT_FOUND_MEMBER));
 		log.debug("{}", member);
 
@@ -156,7 +158,7 @@ public class OauthService {
 		return keys.stream()
 			.filter(key -> Objects.equals(redisTemplate.opsForValue().get(key), refreshToken))
 			.findAny()
-			.map(email -> email.replace("RT:", ""))
+			.map(key -> key.replace("RT:", ""))
 			.orElseThrow(() -> new RestApiException(JwtTokenErrorCode.INVALID_TOKEN));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
@@ -105,7 +105,7 @@ public class OauthService {
 		// key: "RT:" + email, value : 리프레쉬 토큰값
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 
 		return OauthLoginResponse.create(jwt, OauthLoginMemberResponse.from(member));

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthJwtResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthJwtResponse.java
@@ -1,0 +1,20 @@
+package codesquard.app.api.oauth.response;
+
+import codesquard.app.domain.jwt.Jwt;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class OauthJwtResponse {
+	private String accessToken;
+
+	private OauthJwtResponse(String accessToken) {
+		this.accessToken = accessToken;
+	}
+
+	public static OauthJwtResponse create(Jwt jwt) {
+		return new OauthJwtResponse(jwt.getAccessToken());
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
@@ -8,14 +8,14 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class OauthRefreshResponse {
-	private Jwt jwt;
+	private OauthJwtResponse jwt;
 
-	private OauthRefreshResponse(Jwt jwt) {
+	private OauthRefreshResponse(OauthJwtResponse jwt) {
 		this.jwt = jwt;
 	}
 
 	public static OauthRefreshResponse create(Jwt jwt) {
-		return new OauthRefreshResponse(jwt);
+		return new OauthRefreshResponse(OauthJwtResponse.create(jwt));
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
+++ b/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
@@ -34,13 +34,7 @@ public class Jwt {
 		return new Jwt(accessToken, refreshToken, expireDateAccessToken, expireDateRefreshToken);
 	}
 
-	@JsonIgnore
-	public long getExpireDateAccessTokenTime() {
-		return expireDateAccessToken.getTime();
-	}
-
-	@JsonIgnore
-	public long getExpireDateRefreshTokenTime() {
+	public long convertExpireDateRefreshTokenTimeWithLong() {
 		return expireDateRefreshToken.getTime();
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
+++ b/backend/src/main/java/codesquard/app/domain/jwt/Jwt.java
@@ -13,7 +13,9 @@ public class Jwt {
 
 	private String accessToken;
 	private String refreshToken;
+	@JsonIgnore
 	private Date expireDateAccessToken;
+	@JsonIgnore
 	private Date expireDateRefreshToken;
 
 	private Jwt() {

--- a/backend/src/main/java/codesquard/app/domain/member/Member.java
+++ b/backend/src/main/java/codesquard/app/domain/member/Member.java
@@ -82,7 +82,7 @@ public class Member {
 	}
 
 	public String createRedisKey() {
-		return String.format("%s%s-%s", "RT:", email, loginId);
+		return "RT:" + email;
 	}
 
 	public Map<String, Object> createClaims() {

--- a/backend/src/main/java/codesquard/app/domain/member/Member.java
+++ b/backend/src/main/java/codesquard/app/domain/member/Member.java
@@ -80,9 +80,9 @@ public class Member {
 			chatRooms.add(chatRoom);
 		}
 	}
-	
+
 	public String createRedisKey() {
-		return "RT:" + email;
+		return String.format("%s%s-%s", "RT:", email, loginId);
 	}
 
 	public Map<String, Object> createClaims() {

--- a/backend/src/main/java/codesquard/app/domain/member/MemberRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/member/MemberRepository.java
@@ -13,4 +13,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	boolean existsMemberByLoginId(String loginId);
 
 	Optional<Member> findMemberByEmail(String email);
+
+	boolean existsMemberByEmail(String email);
 }

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
@@ -31,7 +31,7 @@ public class OauthFixedFactory {
 		+ "dAZ21haWwuY29tIiwibWVtYmVySWQiOjEsImV4cCI6MTY3MjQ5OTEwMH0.7w2MKSLPVEr6wo7B-C6drNA3eETikpnYi2M1V8c9erY";
 	private static final String SCOPE = "scopeValue";
 	private static final String TOKEN_TYPE = "Bearer";
-	private static final String EMAIL = "23Yong@gmail.com";
+	private static final String EMAIL = "dragonbead95@naver.com";
 	private static final String AVATAR_URL = "avatarUrlValue";
 
 	public static OauthSignUpRequest createFixedOauthSignUpRequest() {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthFixedFactory.java
@@ -38,6 +38,10 @@ public class OauthFixedFactory {
 		return OauthSignUpRequest.create(LOGIN_ID, ADDRESS_NAMES);
 	}
 
+	public static OauthSignUpRequest createOauthSignUpRequest(String loginId, List<String> addressNames) {
+		return OauthSignUpRequest.create(loginId, addressNames);
+	}
+
 	public static OauthSignUpRequest createFixedOauthSignUpRequest(String loginId, List<String> addressNames) {
 		return OauthSignUpRequest.create(loginId, addressNames);
 	}

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -171,8 +171,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("statusCode").value(Matchers.equalTo(200)))
 			.andExpect(jsonPath("message").value(Matchers.equalTo("액세스 토큰 갱신에 성공하였습니다.")))
-			.andExpect(jsonPath("data.jwt.accessToken").isNotEmpty())
-			.andExpect(jsonPath("data.jwt.refreshToken").isNotEmpty());
+			.andExpect(jsonPath("data.jwt.accessToken").isNotEmpty());
 	}
 
 	private static Stream<Arguments> provideInvalidLoginId() {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -267,9 +267,8 @@ class OauthServiceTest extends IntegrationTestSupport {
 		// then
 		SoftAssertions.assertSoftly(softAssertions -> {
 			softAssertions.assertThat(response)
-				.extracting("jwt.accessToken", "jwt.refreshToken")
-				.contains(createExpectedAccessTokenBy(jwtProvider, member, now),
-					createExpectedRefreshTokenBy(jwtProvider, member, now));
+				.extracting("jwt.accessToken")
+				.isEqualTo(createExpectedAccessTokenBy(jwtProvider, member, now));
 			softAssertions.assertAll();
 		});
 	}

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -255,7 +255,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 		memberRepository.save(member);
 
@@ -284,7 +284,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 
 		redisTemplate.opsForValue().set(member.createRedisKey(),
 			jwt.getRefreshToken(),
-			jwt.getExpireDateRefreshTokenTime(),
+			jwt.convertExpireDateRefreshTokenTimeWithLong(),
 			TimeUnit.MILLISECONDS);
 		memberRepository.save(member);
 


### PR DESCRIPTION
## 구현한 것

- 이중 회원가입을 막기 위한 검증문을 추가하였습니다.
- 이중 회원가입에 대한 테스트 코드를 추가하였습니다.

```java
	private void validateMultipleSignUp(String email) {
		if (memberRepository.existsMemberByEmail(email)) {
			throw new RestApiException(OauthErrorCode.ALREADY_SIGNUP);
		}
	}
```