### PR TITLE
[fix] 로그아웃 서비스 문제 해결

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
@@ -8,6 +8,7 @@ import lombok.Getter;
 public enum OauthErrorCode implements ErrorCode {
 	WRONG_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, "잘못된 인가 코드입니다."),
 	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
+	NOT_LOGIN_STATE(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
 	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "provider를 찾을 수 없습니다."),
 	FAIL_LOGIN(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다."),
 	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다.");

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
@@ -65,9 +65,11 @@ public class OauthRestController {
 	}
 
 	@PostMapping(value = "/logout")
-	public ApiResponse<Void> logout(@RequestAttribute String accessToken, @RequestBody String refreshToken) {
-		log.info("로그아웃 요청 입력 : accessToken={}, refreshToken={}", accessToken, refreshToken);
-		oauthService.logout(OauthLogoutRequest.create(accessToken, refreshToken));
+	public ApiResponse<Void> logout(@RequestAttribute String accessToken,
+		@RequestBody OauthLogoutRequest request) {
+		request = OauthLogoutRequest.create(accessToken, request.getRefreshToken());
+		log.info("로그아웃 요청 입력 : request={}", request);
+		oauthService.logout(request);
 		return ApiResponse.ok("로그아웃에 성공하였습니다.", null);
 	}
 

--- a/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
@@ -57,8 +57,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 		}
 		try {
 			String token = extractJwt(request).orElseThrow(() -> new RestApiException(JwtTokenErrorCode.EMPTY_TOKEN));
-			validateAlreadyLogout(token);
 			jwtProvider.validateToken(token);
+			validateAlreadyLogout(token);
 			authenticationContext.setPrincipal(jwtProvider.extractPrincipal(token));
 		} catch (RestApiException e) {
 			setErrorResponse(response, e.getErrorCode());
@@ -80,9 +80,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
 	private void validateAlreadyLogout(String token) {
 		if (Objects.equals(redisTemplate.opsForValue().get(token), "logout")) {
-			throw new RestApiException(OauthErrorCode.ALREADY_LOGOUT);
+			throw new RestApiException(OauthErrorCode.NOT_LOGIN_STATE);
 		}
-		log.debug("이미 로그아웃 검증 통과 : {}", token);
 	}
 
 	private void setErrorResponse(HttpServletResponse httpServletResponse, ErrorCode errorCode) throws IOException {

--- a/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
@@ -1,0 +1,90 @@
+package codesquard.app.filter;
+
+import static codesquard.app.filter.JwtAuthorizationFilter.*;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.util.StringUtils;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtTokenErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
+import codesquard.app.api.errors.exception.RestApiException;
+import codesquard.app.api.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class LogoutFilter extends OncePerRequestFilter {
+
+	private final RedisTemplate<String, Object> redisTemplate;
+	private final ObjectMapper objectMapper;
+
+	private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+	private static final List<String> excludeUrlPatterns = List.of("/api/**");
+
+	@Override
+	protected boolean shouldNotFilter(HttpServletRequest request) {
+		return excludeUrlPatterns.stream()
+			.anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()))
+			&& !pathMatcher.match("/api/auth/logout", request.getRequestURI());
+	}
+
+	@Override
+	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+		FilterChain filterChain) throws ServletException, IOException {
+		if (CorsUtils.isPreFlightRequest(request)) {
+			filterChain.doFilter(request, response);
+			return;
+		}
+		try {
+			String token = extractJwt(request).orElseThrow(() -> new RestApiException(JwtTokenErrorCode.EMPTY_TOKEN));
+			validateAlreadyLogout(token);
+		} catch (RestApiException e) {
+			setErrorResponse(response, e.getErrorCode());
+			return;
+		}
+
+		filterChain.doFilter(request, response);
+	}
+
+	private void validateAlreadyLogout(String token) {
+		if (Objects.equals(redisTemplate.opsForValue().get(token), "logout")) {
+			throw new RestApiException(OauthErrorCode.ALREADY_LOGOUT);
+		}
+		log.debug("이미 로그아웃 검증 통과 : {}", token);
+	}
+
+	private Optional<String> extractJwt(HttpServletRequest request) {
+		String header = request.getHeader(AUTHORIZATION);
+
+		if (!StringUtils.hasText(header) || !header.startsWith(BEARER)) {
+			return Optional.empty();
+		}
+
+		return Optional.of(header.split(" ")[1]);
+	}
+
+	private void setErrorResponse(HttpServletResponse httpServletResponse, ErrorCode errorCode) throws IOException {
+		httpServletResponse.setStatus(errorCode.getHttpStatus().value());
+		httpServletResponse.setContentType("application/json");
+		httpServletResponse.setCharacterEncoding("UTF-8");
+		ApiResponse<Object> body = ApiResponse.error(errorCode);
+		httpServletResponse.getWriter().write(objectMapper.writeValueAsString(body));
+	}
+}

--- a/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
@@ -67,7 +67,6 @@ public class LogoutFilter extends OncePerRequestFilter {
 		if (Objects.equals(redisTemplate.opsForValue().get(token), "logout")) {
 			throw new RestApiException(OauthErrorCode.ALREADY_LOGOUT);
 		}
-		log.debug("이미 로그아웃 검증 통과 : {}", token);
 	}
 
 	private Optional<String> extractJwt(HttpServletRequest request) {

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -95,7 +95,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 		});
 	}
 
-	@DisplayName("중복됝 로그인 아이디로 회원가입을 할 수 없다")
+	@DisplayName("중복된 로그인 아이디로 회원가입을 할 수 없다")
 	@Test
 	public void signupWithDuplicateLoginId() throws IOException {
 		// given
@@ -125,7 +125,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 		String provider = "naver";
 		String code = "1234";
 		MockMultipartFile profile = createFixedProfile();
-		OauthSignUpRequest request = createOauthSignUpRequest("bruni", List.of("가락 1동"));
+		OauthSignUpRequest request = createOauthSignUpRequest("bruni2", List.of("가락 1동"));
 		OauthAccessTokenResponse mockAccessTokenResponse = createFixedOauthAccessTokenResponse();
 		OauthUserProfileResponse mockUserProfileResponse = createOauthUserProfileResponse();
 
@@ -316,7 +316,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 
 		redisTemplate.opsForValue()
 			.set(member.createRedisKey(), jwt.getRefreshToken(),
-				jwt.getExpireDateRefreshTokenTime(), TimeUnit.MILLISECONDS);
+				jwt.getExpireDateRefreshToken().getTime(), TimeUnit.MILLISECONDS);
 		// when
 		oauthService.logout(request);
 
@@ -326,7 +326,7 @@ class OauthServiceTest extends IntegrationTestSupport {
 			softAssertions.assertAll();
 		});
 	}
-
+	
 	@DisplayName("리프레쉬 토큰을 가지고 액세스 토큰을 갱신한다")
 	@Test
 	public void refreshAccessToken() {


### PR DESCRIPTION
## 구현한 것
### 1. 로그아웃 컨트롤러 문제 해결

- 로그아웃 요청시 refreshToken이 json 형태 그대로 전달되는 문제를 해결하였습니다.

<img width="1422" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/59428a68-8e4b-4969-8b2d-e6469d0c4154">

위 로그를 보면 입력으로 받은 refreshToken의 값이 다음과 같은 것을 확인할 수 있었습니다.

```
{"refreshToken":"eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjE2OTQ0NTA3Mzd9.PE_vhehT0nSXMLmMuKUWXsMH0O8dTMiFsn_nX91J4gY"}
```

위와 같은 문제를 해결하기 위해서 컨트롤러 레이어의 코드를 다음과 같이 변경하였습니다.
**기존 코드**
```java
	@PostMapping(value = "/logout")
	public ApiResponse<Void> logout(@RequestAttribute String accessToken, @RequestBody String refreshToken) {
		log.info("로그아웃 요청 입력 : accessToken={}, refreshToken={}", accessToken, refreshToken);
		oauthService.logout(OauthLogoutRequest.create(accessToken, refreshToken));
		return ApiResponse.ok("로그아웃에 성공하였습니다.", null);
	}
```

**변경 코드**
```java
	@PostMapping(value = "/logout")
	public ApiResponse<Void> logout(@RequestAttribute String accessToken,
		@RequestBody OauthLogoutRequest request) {
		request = OauthLogoutRequest.create(accessToken, request.getRefreshToken());
		log.info("로그아웃 요청 입력 : request={}", request);
		oauthService.logout(request);
		return ApiResponse.ok("로그아웃에 성공하였습니다.", null);
	}

```
- accessToken은 LogoutInterceptor 단계에서 Authorization 헤더에서 액세스 토큰을 추출하고 request attribute에 추가하여 받았습니다.

### 2. LogoutFilter 추가
- 기존 로그아웃 서비스 요청시 JwtAuthroziationFilter를 거치게 됩니다. 이때 만료된 액세스 토큰 같은 경우 만료되었다고 응답을 하였습니다. 그런데 로그아웃 설계의 변경(만료된 액세스 토큰이나 만료된 리프레시 토큰이 들어와도 로그아웃 처리할것)으로 인해서 로그아웃 서비스 요청시에는 별도로 핸들링하는 필터가 필요하게 되었습니다.
- 추가한 LogoutFiler는 JwtAuthorizationFilter와 대부분의 기능은 동일하지만 한가지 빠진 것은 jwtProvider.validateToken(token) 로직이 빠져서 토큰이 만료되었는지 검증하지 않습니다. 단, 이미 로그아웃이 되었는지에 대해서는 두 필터(LogoutFilter, JwtAuthorizationFilter) 모두 검증하고 있습니다.

다음 코드는 LogoutFilter 클래스의 핵심적인 로직 부분입니다. Authorization 헤더에서 액세스 토큰을 추출하고 이미 로그아웃 된 상태인지 검증합니다. 이상이 없으면 로그아웃 컨트롤러로 이동됩니다.
```java
	@Override
	protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
		FilterChain filterChain) throws ServletException, IOException {
		if (CorsUtils.isPreFlightRequest(request)) {
			filterChain.doFilter(request, response);
			return;
		}
		try {
			String token = extractJwt(request).orElseThrow(() -> new RestApiException(JwtTokenErrorCode.EMPTY_TOKEN));
			validateAlreadyLogout(token);
		} catch (RestApiException e) {
			setErrorResponse(response, e.getErrorCode());
			return;
		}

		filterChain.doFilter(request, response);
	}
```

## 고민점

- JwtAuthrozationFilter와 LogoutFilter의 내용이 유사하여 중복된 부분이 있습니다. 어떻게 리팩토링할지 고민입니다.
