### PR TITLE
[bug] 로그인 요구 인가 필터에 제외할 경로 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
@@ -28,8 +28,6 @@ import codesquard.app.api.oauth.response.OauthRefreshResponse;
 import codesquard.app.api.oauth.response.OauthSignUpResponse;
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.config.ValidationSequence;
-import codesquard.app.domain.oauth.support.AuthPrincipal;
-import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -75,12 +73,11 @@ public class OauthRestController {
 
 	@ResponseStatus(OK)
 	@PostMapping("/token")
-	public ApiResponse<OauthRefreshResponse> refreshAccessToken(@AuthPrincipal Principal principal,
-		@RequestBody OauthRefreshRequest request) {
-		log.info("{}, {}", principal, request);
+	public ApiResponse<OauthRefreshResponse> refreshAccessToken(@RequestBody OauthRefreshRequest request) {
+		log.info("리프레시 토큰 API 요청 : {}", request);
 
 		OauthRefreshResponse response = oauthService.refreshAccessToken(request, LocalDateTime.now());
-		log.debug("{}", response);
+		log.debug("리프레시 토큰 API 응답 : {}", response);
 		return ApiResponse.ok("액세스 토큰 갱신에 성공하였습니다.", response);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
@@ -57,12 +57,12 @@ public class OauthService {
 
 		OauthUserProfileResponse userProfileResponse = getOauthUserProfileResponse(provider, authorizationCode);
 
-    validateMultipleSignUp(userProfileResponse.getEmail());
-    
+		validateMultipleSignUp(userProfileResponse.getEmail());
+
 		String avatarUrl = optionalProfile.map(imageService::uploadImage)
 			.orElse(userProfileResponse.getProfileImage());
 		log.debug("회원 가입 서비스에서 생성한 아바타 주소 : {}", avatarUrl);
-		
+
 		Member member = request.toEntity(avatarUrl, userProfileResponse.getEmail());
 		Member saveMember = memberRepository.save(member);
 
@@ -151,9 +151,10 @@ public class OauthService {
 		log.debug("refreshToken is valid token : {}", refreshToken);
 
 		String email = findEmailByRefreshToken(refreshToken);
+		log.debug("findEmailByRefreshToken 결과 : email={}", email);
 		Member member = memberRepository.findMemberByEmail(email)
 			.orElseThrow(() -> new RestApiException(MemberErrorCode.NOT_FOUND_MEMBER));
-		log.debug("{}", member);
+		log.debug("findMemberByEmail 결과 : member={}", member);
 
 		Jwt jwt = jwtProvider.createJwtWithRefreshTokenBasedOnMember(member, refreshToken, now);
 

--- a/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
@@ -35,8 +35,12 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 	public static final String AUTHORIZATION = "Authorization";
 	public static final String BEARER = "Bearer";
 	private static final AntPathMatcher pathMatcher = new AntPathMatcher();
-	private static final List<String> excludeUrlPatterns = List.of("/api/auth/**/signup", "/api/auth/**/login",
-		"/api/auth/logout", "/api/auth/token");
+	private static final List<String> excludeUrlPatterns = List.of(
+		"/api/auth/**/signup",
+		"/api/auth/**/login",
+		"/api/auth/token",
+		"/api/auth/logout",
+		"/api/categories");
 	private final JwtProvider jwtProvider;
 	private final AuthenticationContext authenticationContext;
 	private final ObjectMapper objectMapper;
@@ -44,6 +48,14 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 
 	@Override
 	protected boolean shouldNotFilter(HttpServletRequest request) {
+		if (pathMatcher.match("/api/regions", request.getRequestURI())
+			&& Objects.equals("GET", request.getMethod())) {
+			return true;
+		}
+		if (pathMatcher.match("/api/items", request.getRequestURI())
+			&& Objects.equals("GET", request.getMethod())) {
+			return true;
+		}
 		return excludeUrlPatterns.stream()
 			.anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
 	}


### PR DESCRIPTION
## 구현한 것

- 로그인을 요구하는 인가 필터에 제외할 경로를 추가하였습니다.
- 로그인을 요구하지 않는 메소드와 경로는 다음과 같습니다.

```
회원가입 (POST /api/auth/{provider}/signup)
로그인(POST /api/auth/{provider}/login)
액세스 토큰 갱신(POST /api/auth/token)
지역 목록 조회(GET /api/regions)
카테고리 목록 조회(GET /api/categories)
상품 목록 조회(GET /api/items)
- 카테고리별 상품 목록 조회 포함
- 비로그인 상태에서 상품 목록 조회시 기본 지역은 "역삼1동"입니다.
```

## 핵심 코드
"/api/regions"와 "/api/items" 경로의 경우 GET 메소드뿐 아닌 다른 메소드(POST, DELETE)도 있기 때문에 별도의 조건문을 구현하였습니다.

```java
private static final List<String> excludeUrlPatterns = List.of(
		"/api/auth/**/signup",
		"/api/auth/**/login",
		"/api/auth/token",
		"/api/auth/logout",
		"/api/categories");
        // ...

	@Override
	protected boolean shouldNotFilter(HttpServletRequest request) {
		if (pathMatcher.match("/api/regions", request.getRequestURI())
			&& Objects.equals("GET", request.getMethod())) {
			return true;
		}
		if (pathMatcher.match("/api/items", request.getRequestURI())
			&& Objects.equals("GET", request.getMethod())) {
			return true;
		}
		return excludeUrlPatterns.stream()
			.anyMatch(pattern -> pathMatcher.match(pattern, request.getRequestURI()));
	}
```