### PR TITLE
[refactor] 회원 동네 추가/삭제 입력 형식 변경 및 로그인 응답 결과 변경

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
@@ -6,11 +6,11 @@ import lombok.Getter;
 
 @Getter
 public enum OauthErrorCode implements ErrorCode {
-	WRONG_AUTHORIZATION_CODE(HttpStatus.UNAUTHORIZED, "잘못된 인가 코드입니다."),
+	WRONG_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인가 코드입니다."),
 	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
 	NOT_LOGIN_STATE(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
 	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "provider를 찾을 수 없습니다."),
-	FAIL_LOGIN(HttpStatus.BAD_REQUEST, "로그인 정보가 일치하지 않습니다."),
+	FAIL_LOGIN(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),
 	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다.");
 
 	private final HttpStatus httpStatus;

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownValidator.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownValidator.java
@@ -8,6 +8,7 @@ import codesquard.app.api.errors.errorcode.MemberTownErrorCode;
 import codesquard.app.api.errors.errorcode.RegionErrorCode;
 import codesquard.app.api.errors.exception.RestApiException;
 import codesquard.app.domain.membertown.MemberTown;
+import codesquard.app.domain.region.Region;
 import codesquard.app.domain.region.RegionRepository;
 import lombok.RequiredArgsConstructor;
 
@@ -20,17 +21,13 @@ public class MemberTownValidator {
 
 	private final RegionRepository regionRepository;
 
-	public void validateAddMemberTown(List<MemberTown> memberTowns, String fullAddress, String address) {
-		validateExistFullAddress(fullAddress);
-		validateContainsAddress(fullAddress, address);
-		validateDuplicateAddress(memberTowns, address);
+	public void validateAddMemberTown(List<MemberTown> memberTowns, Region region) {
+		validateDuplicateAddress(memberTowns, region);
 		validateMaximumMemberTownSize(memberTowns);
 	}
 
-	public void validateRemoveMemberTown(List<MemberTown> memberTowns, String fullAddress, String address) {
-		validateExistFullAddress(fullAddress);
-		validateContainsAddress(fullAddress, address);
-		validateUnRegisteredAddress(memberTowns, address);
+	public void validateRemoveMemberTown(List<MemberTown> memberTowns, Region region) {
+		validateUnRegisteredAddress(memberTowns, region);
 		validateMinimumMemberTownSize(memberTowns);
 	}
 
@@ -46,20 +43,20 @@ public class MemberTownValidator {
 		}
 	}
 
-	private void validateDuplicateAddress(List<MemberTown> memberTowns, String address) {
+	private void validateDuplicateAddress(List<MemberTown> memberTowns, Region region) {
 		boolean match = memberTowns.stream()
-			.map(MemberTown::getName)
-			.anyMatch(name -> name.equals(address));
+			.map(MemberTown::getRegion)
+			.anyMatch(r -> r.equals(region));
 
 		if (match) {
 			throw new RestApiException(MemberTownErrorCode.ALREADY_ADDRESS_NAME);
 		}
 	}
 
-	private void validateUnRegisteredAddress(List<MemberTown> memberTowns, String address) {
+	private void validateUnRegisteredAddress(List<MemberTown> memberTowns, Region region) {
 		boolean noneMatch = memberTowns.stream()
-			.map(MemberTown::getName)
-			.noneMatch(name -> name.equals(address));
+			.map(MemberTown::getRegion)
+			.noneMatch(r -> r.equals(region));
 
 		if (noneMatch) {
 			throw new RestApiException(MemberTownErrorCode.UNREGISTERED_ADDRESS_TO_REMOVE);

--- a/backend/src/main/java/codesquard/app/api/membertown/request/MemberTownAddRequest.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/request/MemberTownAddRequest.java
@@ -1,6 +1,6 @@
 package codesquard.app.api.membertown.request;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,12 +12,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberTownAddRequest {
 
-	@NotBlank(message = "주소 정보는 필수 정보입니다.")
-	private String fullAddress;
-	@NotBlank(message = "주소 정보는 필수 정보입니다.")
-	private String address;
+	@NotNull(message = "주소 정보는 필수 정보입니다.")
+	private Long addressId;
 
-	public static MemberTownAddRequest create(String fullAddressName, String addressName) {
-		return new MemberTownAddRequest(fullAddressName, addressName);
+	public static MemberTownAddRequest create(Long addressId) {
+		return new MemberTownAddRequest(addressId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/request/MemberTownRemoveRequest.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/request/MemberTownRemoveRequest.java
@@ -1,25 +1,21 @@
 package codesquard.app.api.membertown.request;
 
-import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
 
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class MemberTownRemoveRequest {
-	@NotBlank(message = "주소 정보는 필수 정보입니다.")
-	private String fullAddress;
-	@NotBlank(message = "주소 정보는 필수 정보입니다.")
-	private String address;
 
-	private MemberTownRemoveRequest(String fullAddress, String address) {
-		this.fullAddress = fullAddress;
-		this.address = address;
-	}
+	@NotNull(message = "주소 정보는 필수 정보입니다.")
+	private Long addressId;
 
-	public static MemberTownRemoveRequest create(String fullAddress, String address) {
-		return new MemberTownRemoveRequest(fullAddress, address);
+	public static MemberTownRemoveRequest create(Long addressId) {
+		return new MemberTownRemoveRequest(addressId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/oauth/response/MemberTownLoginResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/MemberTownLoginResponse.java
@@ -1,0 +1,23 @@
+package codesquard.app.api.oauth.response;
+
+import codesquard.app.domain.membertown.MemberTown;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MemberTownLoginResponse {
+	private Long addressId;
+	private String fullAddressName;
+	private String addressName;
+
+	public static MemberTownLoginResponse from(MemberTown memberTown) {
+		return new MemberTownLoginResponse(
+			memberTown.getRegion().getId(),
+			memberTown.getRegion().getName(),
+			memberTown.getName());
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthLoginMemberResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthLoginMemberResponse.java
@@ -1,6 +1,10 @@
 package codesquard.app.api.oauth.response;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import codesquard.app.domain.member.Member;
+import codesquard.app.domain.membertown.MemberTown;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -10,14 +14,18 @@ import lombok.NoArgsConstructor;
 public class OauthLoginMemberResponse {
 	private String loginId;
 	private String profileUrl;
+	private List<MemberTownLoginResponse> addresses;
 
-	private OauthLoginMemberResponse(String loginId, String profileUrl) {
-		this.loginId = loginId;
-		this.profileUrl = profileUrl;
+	private OauthLoginMemberResponse(Member member, List<MemberTown> memberTowns) {
+		this.loginId = member.getLoginId();
+		this.profileUrl = member.getAvatarUrl();
+		this.addresses = memberTowns.stream()
+			.map(MemberTownLoginResponse::from)
+			.collect(Collectors.toUnmodifiableList());
 	}
 
-	public static OauthLoginMemberResponse from(Member member) {
-		return new OauthLoginMemberResponse(member.getLoginId(), member.getAvatarUrl());
+	public static OauthLoginMemberResponse from(Member member, List<MemberTown> memberTowns) {
+		return new OauthLoginMemberResponse(member, memberTowns);
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/OauthRefreshResponse.java
@@ -2,25 +2,23 @@ package codesquard.app.api.oauth.response;
 
 import codesquard.app.domain.jwt.Jwt;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class OauthRefreshResponse {
-	private OauthJwtResponse jwt;
-
-	private OauthRefreshResponse(OauthJwtResponse jwt) {
-		this.jwt = jwt;
-	}
+	private String accessToken;
 
 	public static OauthRefreshResponse create(Jwt jwt) {
-		return new OauthRefreshResponse(OauthJwtResponse.create(jwt));
+		return new OauthRefreshResponse(jwt.getAccessToken());
 	}
 
 	@Override
 	public String toString() {
 		return String.format("%s, %s(accessToken=%s)", "액세스 토큰 갱신 응답", this.getClass().getSimpleName(),
-			jwt.getAccessToken());
+			accessToken);
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
@@ -1,9 +1,7 @@
 package codesquard.app.domain.membertown;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -49,17 +47,14 @@ public class MemberTown {
 	public static List<MemberTown> create(List<Region> regions, Member member) {
 		List<MemberTown> memberTowns = new ArrayList<>();
 		for (Region region : regions) {
-			String name = convertShortAddressName(region.getName());
-			memberTowns.add(create(name, member, region));
+			memberTowns.add(create(region, member));
 		}
 		return memberTowns;
 	}
 
-	private static String convertShortAddressName(String fullAddressName) {
-		final String space = " ";
-		return Arrays.stream(fullAddressName.split(space))
-			.skip(2)
-			.collect(Collectors.joining(space));
+	public static MemberTown create(Region region, Member member) {
+		String name = region.getShortAddress();
+		return create(name, member, region);
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
@@ -1,7 +1,9 @@
 package codesquard.app.domain.membertown;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
@@ -12,6 +14,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 
 import codesquard.app.domain.member.Member;
+import codesquard.app.domain.region.Region;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -29,21 +32,34 @@ public class MemberTown {
 	@JoinColumn(name = "member_id")
 	private Member member;
 
-	private MemberTown(String name, Member member) {
+	@ManyToOne
+	@JoinColumn(name = "region_id")
+	private Region region;
+
+	private MemberTown(String name, Member member, Region region) {
 		this.name = name;
 		this.member = member;
+		this.region = region;
 	}
 
-	public static MemberTown create(String name, Member member) {
-		return new MemberTown(name, member);
+	public static MemberTown create(String name, Member member, Region region) {
+		return new MemberTown(name, member, region);
 	}
 
-	public static List<MemberTown> create(List<String> names, Member member) {
+	public static List<MemberTown> create(List<Region> regions, Member member) {
 		List<MemberTown> memberTowns = new ArrayList<>();
-		for (String name : names) {
-			memberTowns.add(create(name, member));
+		for (Region region : regions) {
+			String name = convertShortAddressName(region.getName());
+			memberTowns.add(create(name, member, region));
 		}
 		return memberTowns;
+	}
+
+	private static String convertShortAddressName(String fullAddressName) {
+		final String space = " ";
+		return Arrays.stream(fullAddressName.split(space))
+			.skip(2)
+			.collect(Collectors.joining(space));
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
@@ -12,5 +12,5 @@ public interface MemberTownRepository extends JpaRepository<MemberTown, Long> {
 
 	Optional<MemberTown> findMemberTownByMemberIdAndName(Long memberId, String name);
 
-	void deleteMemberTownByMemberIdAndName(Long memberId, String name);
+	void deleteMemberTownByMemberIdAndRegionId(Long memberId, Long regionId);
 }

--- a/backend/src/main/java/codesquard/app/domain/region/Region.java
+++ b/backend/src/main/java/codesquard/app/domain/region/Region.java
@@ -1,5 +1,8 @@
 package codesquard.app.domain.region;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -28,5 +31,12 @@ public class Region {
 	@Override
 	public String toString() {
 		return String.format("%s, %s(id=%d, name=%s)", "지역", this.getClass().getSimpleName(), id, name);
+	}
+
+	public String getShortAddress() {
+		final String space = " ";
+		return Arrays.stream(name.split(space))
+			.skip(2)
+			.collect(Collectors.joining(space));
 	}
 }

--- a/backend/src/test/java/codesquard/app/IntegrationTestSupport.java
+++ b/backend/src/test/java/codesquard/app/IntegrationTestSupport.java
@@ -1,5 +1,8 @@
 package codesquard.app;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.AfterEach;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -18,6 +21,7 @@ import codesquard.app.domain.image.ImageRepository;
 import codesquard.app.domain.item.ItemRepository;
 import codesquard.app.domain.member.MemberRepository;
 import codesquard.app.domain.membertown.MemberTownRepository;
+import codesquard.app.domain.region.Region;
 import codesquard.app.domain.region.RegionPaginationRepository;
 import codesquard.app.domain.region.RegionRepository;
 import codesquard.app.domain.wish.WishRepository;
@@ -90,5 +94,23 @@ public abstract class IntegrationTestSupport {
 		categoryRepository.deleteAllInBatch();
 		memberTownRepository.deleteAllInBatch();
 		memberRepository.deleteAllInBatch();
+	}
+
+	protected List<Long> getAddressIds(String name) {
+		List<Region> regions = regionRepository.findAllByNameIn(List.of(name));
+		return regions.stream()
+			.map(Region::getId)
+			.collect(Collectors.toUnmodifiableList());
+	}
+
+	protected List<Region> getRegions(List<String> names) {
+		return regionRepository.findAllByNameIn(names);
+	}
+
+	protected Region getRegion(String name) {
+		return regionRepository.findAllByNameIn(List.of(name))
+			.stream()
+			.findAny()
+			.orElseThrow();
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
@@ -26,6 +26,7 @@ import codesquard.app.domain.member.Member;
 import codesquard.app.domain.membertown.MemberTown;
 import codesquard.app.domain.oauth.support.AuthPrincipalArgumentResolver;
 import codesquard.app.domain.oauth.support.Principal;
+import codesquard.app.domain.region.Region;
 
 class MemberTownRestControllerTest extends ControllerTestSupport {
 
@@ -43,13 +44,13 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 			.build();
 	}
 
-	@DisplayName("전체 주소와 동 주소를 가지고 회원 동네를 추가한다")
+	@DisplayName("주소 등록번호를 가지고 회원 동네를 추가한다")
 	@Test
 	public void addMemberTown() throws Exception {
 		// given
-		MemberTownAddRequest request = MemberTownAddRequest.create("서울 송파구 가락동", "가락동");
+		MemberTownAddRequest request = MemberTownAddRequest.create(1L);
 		Member member = OauthFixedFactory.createFixedMember();
-		MemberTown memberTown = MemberTown.create("가락동", member);
+		MemberTown memberTown = MemberTown.create(Region.create("서울 송파구 가락동"), member);
 		MemberAddRegionResponse response = MemberAddRegionResponse.create(memberTown);
 		given(memberTownService.addMemberTown(
 			ArgumentMatchers.any(Principal.class),
@@ -66,12 +67,12 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("data").value(equalTo(null)));
 	}
 
-	@DisplayName("전체 주소와 동주소를 가지고 회원의 동네를 삭제한다")
+	@DisplayName("주소 등록번호를 가지고 회원의 동네를 삭제한다")
 	@Test
 	public void removeMemberTown() throws Exception {
 		// given
-		MemberTownRemoveRequest request = MemberTownRemoveRequest.create("서울 송파구 가락동", "가락동");
-		MemberTownRemoveResponse response = MemberTownRemoveResponse.create("가락동");
+		MemberTownRemoveRequest request = MemberTownRemoveRequest.create(1L);
+		MemberTownRemoveResponse response = MemberTownRemoveResponse.create("서울 송파구 가락동");
 		given(memberTownService.removeMemberTown(
 			ArgumentMatchers.any(Principal.class),
 			ArgumentMatchers.any(MemberTownRemoveRequest.class)))
@@ -87,11 +88,11 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("data").value(equalTo(null)));
 	}
 
-	@DisplayName("전체 주소와 동주소의 이름은 null이면 회원의 동네를 제거할 수 없다")
+	@DisplayName("주소 등록번호가 null이면 회원의 동네를 제거할 수 없다")
 	@Test
 	public void removeMemberTownWithAddressIsNull() throws Exception {
 		// given
-		MemberTownRemoveRequest request = MemberTownRemoveRequest.create(null, null);
+		MemberTownRemoveRequest request = MemberTownRemoveRequest.create(null);
 		// when & then
 		mockMvc.perform(delete("/api/regions")
 				.content(objectMapper.writeValueAsString(request))
@@ -99,8 +100,8 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isBadRequest())
 			.andExpect(jsonPath("statusCode").value(equalTo(400)))
 			.andExpect(jsonPath("message").value(equalTo("유효하지 않은 입력형식입니다.")))
-			.andExpect(jsonPath("data[*].field").value(containsInAnyOrder("fullAddress", "address")))
+			.andExpect(jsonPath("data[*].field").value(containsInAnyOrder("addressId")))
 			.andExpect(jsonPath("data[*].defaultMessage")
-				.value(containsInAnyOrder("주소 정보는 필수 정보입니다.", "주소 정보는 필수 정보입니다.")));
+				.value(containsInAnyOrder("주소 정보는 필수 정보입니다.")));
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -167,7 +167,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("statusCode").value(Matchers.equalTo(200)))
 			.andExpect(jsonPath("message").value(Matchers.equalTo("액세스 토큰 갱신에 성공하였습니다.")))
-			.andExpect(jsonPath("data.jwt.accessToken").isNotEmpty());
+			.andExpect(jsonPath("data.accessToken").isNotEmpty());
 	}
 
 	private static Stream<Arguments> provideInvalidLoginId() {


### PR DESCRIPTION
## 구현한 것

- 회원 동네 추가/삭제 요청시 기존 문자열 주소를 전달하는 것에서 주소의 등록번호를 전달하는 것으로 변경하여 구현하였습니다.
- 로그인 응답시 회원이 등록한 동네의 정보들을 응답할 수 있도록 변경하였습니다.

## 실행결과
### 로그인 실행 결과
<img width="937" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/2ceb3f73-42f6-4bd2-b3b0-108e081f88e2">

### 동네 추가 실행 결과
<img width="963" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/b8f05d5c-b443-4324-8242-9ad50b886794">

### 동네 삭제 실행 결과
<img width="955" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/9da4d003-9976-423c-a480-9d4f5a6d8a31">
