### PR TITLE
[feat] 4주차 리뷰사항 반영

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/WishErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/WishErrorCode.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 @Getter
 public enum WishErrorCode implements ErrorCode {
 
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
+	DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "이미 처리된 요청입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -22,9 +22,9 @@ public class WishItemController {
 	private final WishItemService wishItemService;
 
 	@PostMapping("/{itemId}")
-	public ApiResponse<Void> wishStatus(@PathVariable Long itemId, @RequestParam WishStatus wish,
+	public ApiResponse<Void> wishStatus(@PathVariable Long itemId, @RequestParam WishStatus status,
 		@AuthPrincipal Principal principal) {
-		wish.doMethod(wishItemService, itemId, principal.getMemberId());
+		wishItemService.changeWishStatus(itemId, principal.getMemberId(), status);
 		return ApiResponse.ok("관심상품 변경이 완료되었습니다.", null);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -7,41 +7,49 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.api.errors.errorcode.ItemErrorCode;
-import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.WishErrorCode;
 import codesquard.app.api.errors.exception.RestApiException;
 import codesquard.app.api.response.ItemResponse;
 import codesquard.app.api.response.ItemResponses;
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.item.ItemRepository;
 import codesquard.app.domain.member.Member;
-import codesquard.app.domain.member.MemberRepository;
 import codesquard.app.domain.pagination.PaginationUtils;
 import codesquard.app.domain.wish.Wish;
 import codesquard.app.domain.wish.WishPaginationRepository;
 import codesquard.app.domain.wish.WishRepository;
+import codesquard.app.domain.wish.WishStatus;
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class WishItemService {
 
-	private final MemberRepository memberRepository;
 	private final ItemRepository itemRepository;
 	private final WishRepository wishRepository;
 	private final WishPaginationRepository wishPaginationRepository;
 
 	@Transactional
-	public void register(Long itemId, Long memberId) {
-		Item item = itemRepository.findById(itemId)
-			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
-		item.wishRegister();
-		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new RestApiException(MemberErrorCode.NOT_FOUND_MEMBER));
-		wishRepository.save(Wish.create(member, item, LocalDateTime.now()));
+	public void changeWishStatus(Long itemId, Long memberId, WishStatus status) {
+		if (status == WishStatus.YES) {
+			register(itemId, memberId);
+			return;
+		}
+		cancel(itemId);
 	}
 
-	@Transactional
-	public void cancel(Long itemId) {
+	private void register(Long itemId, Long memberId) {
+		Item item = itemRepository.findById(itemId)
+			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
+		if (wishRepository.existsByMemberIdAndItemId(memberId, itemId)) {
+			throw new RestApiException(WishErrorCode.DUPLICATED_REQUEST);
+		} else {
+			item.wishRegister();
+			wishRepository.save(Wish.create(new Member(memberId), item, LocalDateTime.now()));
+		}
+	}
+
+	private void cancel(Long itemId) {
 		Item item = itemRepository.findById(itemId)
 			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
 		item.wishCancel();

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -43,10 +43,9 @@ public class WishItemService {
 			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
 		if (wishRepository.existsByMemberIdAndItemId(memberId, itemId)) {
 			throw new RestApiException(WishErrorCode.DUPLICATED_REQUEST);
-		} else {
-			item.wishRegister();
-			wishRepository.save(Wish.create(new Member(memberId), item, LocalDateTime.now()));
 		}
+		item.wishRegister();
+		wishRepository.save(Wish.create(new Member(memberId), item, LocalDateTime.now()));
 	}
 
 	private void cancel(Long itemId) {

--- a/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
@@ -11,14 +11,14 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import codesquard.app.api.response.ItemResponse;
-import codesquard.app.domain.pagination.PaginationUtils;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Repository
-public class ItemPaginationRepository extends PaginationUtils {
+public class ItemPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
+	private final ItemRepository itemRepository;
 
 	public Slice<ItemResponse> findByIdAndRegion(Long itemId, String region, int size, Long categoryId) {
 		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
@@ -32,13 +32,13 @@ public class ItemPaginationRepository extends PaginationUtils {
 				item.wishCount,
 				item.chatCount))
 			.from(item)
-			.where(lessThanItemId(itemId),
-				equalCategoryId(categoryId),
-				equalTradingRegion(region)
+			.where(itemRepository.lessThanItemId(itemId),
+				itemRepository.equalCategoryId(categoryId),
+				itemRepository.equalTradingRegion(region)
 			)
 			.orderBy(item.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
-		return checkLastPage(size, itemResponses);
+		return itemRepository.checkLastPage(size, itemResponses);
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/item/ItemRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemRepository.java
@@ -1,6 +1,64 @@
 package codesquard.app.domain.item;
 
+import static codesquard.app.domain.item.QItem.*;
+
+import java.util.List;
+
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+
+import codesquard.app.api.response.ItemResponse;
+import codesquard.app.domain.sales.SalesStatus;
+
 public interface ItemRepository extends JpaRepository<Item, Long> {
+
+	default BooleanExpression lessThanItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+
+		return item.id.lt(itemId);
+	}
+
+	default BooleanExpression equalCategoryId(Long categoryId) {
+		if (categoryId == null) {
+			return null;
+		}
+
+		return item.category.id.eq(categoryId);
+	}
+
+	default BooleanExpression equalTradingRegion(String region) {
+		if (region == null) {
+			return null;
+		}
+
+		return item.region.like(region + "%");
+	}
+
+	default BooleanExpression equalsStatus(SalesStatus status) {
+		if (status == SalesStatus.ON_SALE) {
+			return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED);
+		} else if (status == SalesStatus.SOLD_OUT) {
+			return item.status.eq(ItemStatus.SOLD_OUT);
+		}
+		return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED, ItemStatus.SOLD_OUT);
+	}
+
+	default SliceImpl<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
+
+		boolean hasNext = false;
+
+		// 조회한 결과 개수가 요청한 페이지 사이즈보다 다음 페이지 존재, next = true
+		if (results.size() > size) {
+			hasNext = true;
+			results.remove(size);
+		}
+
+		return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
+	}
+
 }

--- a/backend/src/main/java/codesquard/app/domain/pagination/PaginationUtils.java
+++ b/backend/src/main/java/codesquard/app/domain/pagination/PaginationUtils.java
@@ -1,67 +1,13 @@
 package codesquard.app.domain.pagination;
 
-import static codesquard.app.domain.item.QItem.*;
-
 import java.util.List;
 
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
-
-import com.querydsl.core.types.dsl.BooleanExpression;
 
 import codesquard.app.api.response.ItemResponse;
 import codesquard.app.api.response.ItemResponses;
-import codesquard.app.domain.item.ItemStatus;
-import codesquard.app.domain.sales.SalesStatus;
 
 public class PaginationUtils {
-
-	public static BooleanExpression lessThanItemId(Long itemId) {
-		if (itemId == null) {
-			return null;
-		}
-
-		return item.id.lt(itemId);
-	}
-
-	public static BooleanExpression equalCategoryId(Long categoryId) {
-		if (categoryId == null) {
-			return null;
-		}
-
-		return item.category.id.eq(categoryId);
-	}
-
-	public static BooleanExpression equalTradingRegion(String region) {
-		if (region == null) {
-			return null;
-		}
-
-		return item.region.like(region + "%");
-	}
-
-	public static BooleanExpression equalsStatus(SalesStatus status) {
-		if (status == SalesStatus.ON_SALE) {
-			return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED);
-		} else if (status == SalesStatus.SOLD_OUT) {
-			return item.status.eq(ItemStatus.SOLD_OUT);
-		}
-		return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED, ItemStatus.SOLD_OUT);
-	}
-
-	public static Slice<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
-
-		boolean hasNext = false;
-
-		// 조회한 결과 개수가 요청한 페이지 사이즈보다 다음 페이지 존재, next = true
-		if (results.size() > size) {
-			hasNext = true;
-			results.remove(size);
-		}
-
-		return new SliceImpl<>(results, PageRequest.ofSize(size), hasNext);
-	}
 
 	public static ItemResponses getItemResponses(Slice<ItemResponse> itemResponses) {
 		List<ItemResponse> contents = itemResponses.getContent();

--- a/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
@@ -11,14 +11,15 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import codesquard.app.api.response.ItemResponse;
-import codesquard.app.domain.pagination.PaginationUtils;
+import codesquard.app.domain.item.ItemRepository;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Repository
-public class SalesPaginationRepository extends PaginationUtils {
+public class SalesPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
+	private final ItemRepository itemRepository;
 
 	public Slice<ItemResponse> findAll(SalesStatus status, int size, Long cursor) {
 		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
@@ -30,11 +31,11 @@ public class SalesPaginationRepository extends PaginationUtils {
 				item.price,
 				item.status))
 			.from(item)
-			.where(lessThanItemId(cursor),
-				equalsStatus(status))
+			.where(itemRepository.lessThanItemId(cursor),
+				itemRepository.equalsStatus(status))
 			.orderBy(item.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
-		return checkLastPage(size, itemResponses);
+		return itemRepository.checkLastPage(size, itemResponses);
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishPaginationRepository.java
@@ -12,14 +12,15 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import codesquard.app.api.response.ItemResponse;
-import codesquard.app.domain.pagination.PaginationUtils;
+import codesquard.app.domain.item.ItemRepository;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Repository
-public class WishPaginationRepository extends PaginationUtils {
+public class WishPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
+	private final ItemRepository itemRepository;
 
 	public Slice<ItemResponse> findAll(Long categoryId, int size, Long cursor) {
 		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
@@ -35,11 +36,11 @@ public class WishPaginationRepository extends PaginationUtils {
 			.from(wish)
 			.join(wish.item, item)
 			.on(wish.item.id.eq(item.id))
-			.where(lessThanItemId(cursor),
-				equalCategoryId(categoryId))
+			.where(itemRepository.lessThanItemId(cursor),
+				itemRepository.equalCategoryId(categoryId))
 			.orderBy(wish.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
-		return checkLastPage(size, itemResponses);
+		return itemRepository.checkLastPage(size, itemResponses);
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
@@ -7,4 +7,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 	void deleteByItemId(Long itemId);
 
 	int countWishByItemId(Long itemId);
+
+	boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishStatus.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishStatus.java
@@ -4,7 +4,6 @@ import java.util.Arrays;
 
 import codesquard.app.api.errors.errorcode.WishErrorCode;
 import codesquard.app.api.errors.exception.RestApiException;
-import codesquard.app.api.wishitem.WishItemService;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -12,18 +11,8 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public enum WishStatus {
 
-	YES("yes") {
-		@Override
-		public void doMethod(WishItemService wishItemService, Long itemId, Long memberId) {
-			wishItemService.register(itemId, memberId);
-		}
-	},
-	NO("no") {
-		@Override
-		public void doMethod(WishItemService wishItemService, Long itemId, Long memberId) {
-			wishItemService.cancel(itemId);
-		}
-	};
+	YES("yes"),
+	NO("no");
 
 	private final String status;
 
@@ -33,6 +22,4 @@ public enum WishStatus {
 			.findFirst()
 			.orElseThrow(() -> new RestApiException(WishErrorCode.INVALID_PARAMETER));
 	}
-
-	public abstract void doMethod(WishItemService wishItemService, Long itemId, Long memberId);
 }

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
@@ -20,7 +20,7 @@ import codesquard.app.domain.category.Category;
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.item.ItemStatus;
 import codesquard.app.domain.member.Member;
-import codesquard.support.SupportRepository;
+import codesquard.app.domain.wish.WishStatus;
 
 @SpringBootTest
 class WishItemServiceTest extends IntegrationTestSupport {
@@ -29,8 +29,6 @@ class WishItemServiceTest extends IntegrationTestSupport {
 	private WishItemService wishItemService;
 	@Autowired
 	private EntityManager em;
-	@Autowired
-	private SupportRepository supportRepository;
 
 	@Test
 	@DisplayName("관심상품 등록에 성공한다.")
@@ -45,7 +43,7 @@ class WishItemServiceTest extends IntegrationTestSupport {
 		Item item1 = supportRepository.save(request.toEntity(member, "thumbnail"));
 
 		// when
-		wishItemService.register(item1.getId(), member.getId());
+		wishItemService.changeWishStatus(item1.getId(), member.getId(), WishStatus.YES);
 
 		// then
 		Item item = em.find(Item.class, item1.getId());
@@ -62,10 +60,10 @@ class WishItemServiceTest extends IntegrationTestSupport {
 			"선풍기", 12000L, null, "가양 1동", ItemStatus.ON_SALE, category.getId(), null);
 		Member member = supportRepository.save(Member.create("avatar", "pie@pie", "piepie"));
 		Item saveItem = supportRepository.save(request1.toEntity(member, "thumbnail"));
-		wishItemService.register(saveItem.getId(), member.getId());
+		wishItemService.changeWishStatus(saveItem.getId(), member.getId(), WishStatus.YES);
 
 		// when
-		wishItemService.cancel(saveItem.getId());
+		wishItemService.changeWishStatus(saveItem.getId(), member.getId(), WishStatus.NO);
 
 		// then
 		Item item = em.find(Item.class, saveItem.getId());
@@ -89,9 +87,9 @@ class WishItemServiceTest extends IntegrationTestSupport {
 		Item item1 = supportRepository.save(request1.toEntity(member, "thumbnail"));
 		Item item2 = supportRepository.save(request2.toEntity(member, "thumb"));
 		Item item3 = supportRepository.save(request3.toEntity(member, "nail"));
-		wishItemService.register(item1.getId(), member.getId());
-		wishItemService.register(item2.getId(), member.getId());
-		wishItemService.register(item3.getId(), member.getId());
+		wishItemService.changeWishStatus(item1.getId(), member.getId(), WishStatus.YES);
+		wishItemService.changeWishStatus(item2.getId(), member.getId(), WishStatus.YES);
+		wishItemService.changeWishStatus(item3.getId(), member.getId(), WishStatus.YES);
 
 		// when
 		Long categoryId = null;
@@ -126,15 +124,14 @@ class WishItemServiceTest extends IntegrationTestSupport {
 		Item item1 = supportRepository.save(request1.toEntity(member, "thumbnail"));
 		Item item2 = supportRepository.save(request2.toEntity(member, "thumb"));
 		Item item3 = supportRepository.save(request3.toEntity(member, "nail"));
-		wishItemService.register(item1.getId(), member.getId());
-		wishItemService.register(item2.getId(), member.getId());
-		wishItemService.register(item3.getId(), member.getId());
+		wishItemService.changeWishStatus(item1.getId(), member.getId(), WishStatus.YES);
+		wishItemService.changeWishStatus(item2.getId(), member.getId(), WishStatus.YES);
+		wishItemService.changeWishStatus(item3.getId(), member.getId(), WishStatus.YES);
 
 		// when
 		ItemResponses responses = wishItemService.findAll(category1.getId(), 10, null);
 
 		// then
 		assertThat(responses.getContents()).hasSize(2);
-
 	}
 }


### PR DESCRIPTION
## 구현한 것
- `PaginationUtils`에서 처리하던 item관련 메서드를 `ItemRepository`로 이동
- `WishStatus`에서 처리하던 메서드들을 `Service`로 이동 
- `WishItemService`에서 한 아이템에 대해 wish 등록 요청을 보낸 memberId가 있는지 검증