### PR TITLE
[refactor] 상품 게시글 수정시 썸네일 로직 개선

### DIFF
--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -63,10 +63,11 @@ public class ItemController {
 
 	@PatchMapping("/{itemId}")
 	public ApiResponse<Void> modifyItem(@PathVariable Long itemId,
-		@RequestPart("images") List<MultipartFile> addImages,
+		@RequestPart(value = "images", required = false) List<MultipartFile> addImages,
 		@Valid @RequestPart("item") ItemModifyRequest request,
+		@RequestPart(value = "thumnailImage", required = false) MultipartFile thumnailImage,
 		@AuthPrincipal Principal principal) {
-		itemService.modifyItem(itemId, request, addImages, principal);
+		itemService.modifyItem(itemId, request, addImages, thumnailImage, principal);
 		return ApiResponse.ok("상품 수정을 완료하였습니다.", null);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -65,9 +65,9 @@ public class ItemController {
 	public ApiResponse<Void> modifyItem(@PathVariable Long itemId,
 		@RequestPart(value = "images", required = false) List<MultipartFile> addImages,
 		@Valid @RequestPart("item") ItemModifyRequest request,
-		@RequestPart(value = "thumnailImage", required = false) MultipartFile thumnailImage,
+		@RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage,
 		@AuthPrincipal Principal principal) {
-		itemService.modifyItem(itemId, request, addImages, thumnailImage, principal);
+		itemService.modifyItem(itemId, request, addImages, thumbnailImage, principal);
 		return ApiResponse.ok("상품 수정을 완료하였습니다.", null);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -120,13 +120,13 @@ public class ItemService {
 			.orElseThrow(() -> new RestApiException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 	}
 
-	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumnailUrl) {
-		if (!thumbnailFile.isEmpty()) {
+	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumbnailUrl) {
+		if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
 			String thumnail = updateNewThumnail(item.getId(), thumbnailFile);
 			return updateThumbnailStatus(thumnail, item);
 		}
-		if (thumnailUrl != null) {
-			return updateThumbnailStatus(thumnailUrl, item);
+		if (thumbnailUrl != null) {
+			return updateThumbnailStatus(thumbnailUrl, item);
 		}
 		return item.getThumbnailUrl();
 	}

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -145,7 +145,7 @@ public class ItemService {
 			return null;
 		}
 
-		int result = imageRepository.updateAllThumnailIsFalseByItemId(item.getId());
+		int result = imageRepository.updateThumnailToFalseByItemIdAndThumbnailIsTrue(item.getId());
 		log.debug("기존 이미지 썸네일 표시 변경 결과 : result={}", result);
 
 		result = imageRepository.updateThumbnailByItemIdAndImageUrl(item.getId(), changeThumbnail, true);

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -122,8 +122,8 @@ public class ItemService {
 
 	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumbnailUrl) {
 		if (thumbnailFile != null && !thumbnailFile.isEmpty()) {
-			String thumnail = updateNewThumnail(item.getId(), thumbnailFile);
-			return updateThumbnailStatus(thumnail, item);
+			String thumbnail = updateNewThumnail(item.getId(), thumbnailFile);
+			return updateThumbnailStatus(thumbnail, item);
 		}
 		if (thumbnailUrl != null) {
 			return updateThumbnailStatus(thumbnailUrl, item);
@@ -135,8 +135,8 @@ public class ItemService {
 		String thumnailImageUrl = imageService.uploadImage(thumbnailFile);
 		log.debug("썸네일 이미지 S3 업로드 결과 : thumnailImageUrl={}", thumnailImageUrl);
 
-		Image thumnail = imageRepository.save(Image.thumnail(thumnailImageUrl, itemId));
-		log.debug("썸네일 이미지 테이블 저장 결과 : image={}", thumnail);
+		Image thumbnail = imageRepository.save(Image.thumbnail(thumnailImageUrl, itemId));
+		log.debug("썸네일 이미지 테이블 저장 결과 : image={}", thumbnail);
 		return thumnailImageUrl;
 	}
 

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -88,6 +88,7 @@ public class ItemService {
 	public void modifyItem(Long itemId, ItemModifyRequest request, List<MultipartFile> addImages,
 		MultipartFile thumnailFile, Principal writer) {
 		log.info("상품 수정 서비스 요청 : itemId={}, request={}, writer={}", itemId, request, writer.getLoginId());
+		log.info("상품 수정 서비스 요청 : addImages={}, thumnailFile={}", addImages, thumnailFile);
 
 		Item item = findItemBy(itemId);
 		log.debug("상품 수정 서비스의 상품 조회 결과 : {}", item);
@@ -120,11 +121,12 @@ public class ItemService {
 	}
 
 	private String updateThumnail(Item item, MultipartFile thumnailFile, String thumnailUrl) {
-		if (thumnailFile != null) {
-			return updateNewThumnail(item.getId(), thumnailFile);
+		if (!thumnailFile.isEmpty()) {
+			String thumnail = updateNewThumnail(item.getId(), thumnailFile);
+			return updateThumnail(thumnail, item);
 		}
 		if (thumnailUrl != null) {
-			return updateExistThumnail(thumnailUrl, item);
+			return updateThumnail(thumnailUrl, item);
 		}
 		return item.getThumbnailUrl();
 	}
@@ -138,15 +140,12 @@ public class ItemService {
 		return thumnailImageUrl;
 	}
 
-	private String updateExistThumnail(String changeThumnail, Item item) {
+	private String updateThumnail(String changeThumnail, Item item) {
 		if (changeThumnail == null) {
 			return null;
 		}
-		if (!item.equalThumnailImageUrl(changeThumnail)) {
-			return null;
-		}
 
-		int result = imageRepository.updateThumnailByItemIdAndImageUrl(item.getId(), item.getThumbnailUrl(), false);
+		int result = imageRepository.updateAllThumnailIsFalseByItemId(item.getId());
 		log.debug("기존 이미지 썸네일 표시 변경 결과 : result={}", result);
 
 		result = imageRepository.updateThumnailByItemIdAndImageUrl(item.getId(), changeThumnail, true);

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -86,9 +86,9 @@ public class ItemService {
 
 	@Transactional
 	public void modifyItem(Long itemId, ItemModifyRequest request, List<MultipartFile> addImages,
-		MultipartFile thumnailFile, Principal writer) {
+		MultipartFile thumbnailFile, Principal writer) {
 		log.info("상품 수정 서비스 요청 : itemId={}, request={}, writer={}", itemId, request, writer.getLoginId());
-		log.info("상품 수정 서비스 요청 : addImages={}, thumnailFile={}", addImages, thumnailFile);
+		log.info("상품 수정 서비스 요청 : addImages={}, thumnailFile={}", addImages, thumbnailFile);
 
 		Item item = findItemBy(itemId);
 		log.debug("상품 수정 서비스의 상품 조회 결과 : {}", item);
@@ -109,7 +109,7 @@ public class ItemService {
 		Category category = findCategoryBy(request.getCategoryId());
 		log.debug("상품 수정 서비스의 카테고리 조회 결과 : {}", category);
 
-		String thumbnailUrl = updateThumnail(item, thumnailFile, request.getThumnailImage());
+		String thumbnailUrl = updateThumnail(item, thumbnailFile, request.getThumnailImage());
 		log.debug("썸네일 갱신 결과 : thumbnailUrl={}", thumbnailUrl);
 
 		item.change(category, request.toEntity(), thumbnailUrl);
@@ -120,19 +120,19 @@ public class ItemService {
 			.orElseThrow(() -> new RestApiException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 	}
 
-	private String updateThumnail(Item item, MultipartFile thumnailFile, String thumnailUrl) {
-		if (!thumnailFile.isEmpty()) {
-			String thumnail = updateNewThumnail(item.getId(), thumnailFile);
-			return updateThumnail(thumnail, item);
+	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumnailUrl) {
+		if (!thumbnailFile.isEmpty()) {
+			String thumnail = updateNewThumnail(item.getId(), thumbnailFile);
+			return updateThumbnailStatus(thumnail, item);
 		}
 		if (thumnailUrl != null) {
-			return updateThumnail(thumnailUrl, item);
+			return updateThumbnailStatus(thumnailUrl, item);
 		}
 		return item.getThumbnailUrl();
 	}
 
-	private String updateNewThumnail(Long itemId, MultipartFile thumnailFile) {
-		String thumnailImageUrl = imageService.uploadImage(thumnailFile);
+	private String updateNewThumnail(Long itemId, MultipartFile thumbnailFile) {
+		String thumnailImageUrl = imageService.uploadImage(thumbnailFile);
 		log.debug("썸네일 이미지 S3 업로드 결과 : thumnailImageUrl={}", thumnailImageUrl);
 
 		Image thumnail = imageRepository.save(Image.thumnail(thumnailImageUrl, itemId));
@@ -140,18 +140,18 @@ public class ItemService {
 		return thumnailImageUrl;
 	}
 
-	private String updateThumnail(String changeThumnail, Item item) {
-		if (changeThumnail == null) {
+	private String updateThumbnailStatus(String changeThumbnail, Item item) {
+		if (changeThumbnail == null) {
 			return null;
 		}
 
 		int result = imageRepository.updateAllThumnailIsFalseByItemId(item.getId());
 		log.debug("기존 이미지 썸네일 표시 변경 결과 : result={}", result);
 
-		result = imageRepository.updateThumnailByItemIdAndImageUrl(item.getId(), changeThumnail, true);
+		result = imageRepository.updateThumbnailByItemIdAndImageUrl(item.getId(), changeThumbnail, true);
 		log.debug("요청 이미지 썸네일 표시 변경 결과 : result={}", result);
 
-		return changeThumnail;
+		return changeThumbnail;
 	}
 
 	private int deleteImages(Long itemId, List<String> deleteImageUrls) {

--- a/backend/src/main/java/codesquard/app/api/item/request/ItemModifyRequest.java
+++ b/backend/src/main/java/codesquard/app/api/item/request/ItemModifyRequest.java
@@ -32,6 +32,7 @@ public class ItemModifyRequest {
 	@NotBlank(message = "카테고리명은 필수 정보입니다.")
 	private String categoryName;
 	private List<String> deleteImageUrls;
+	private String thumnailImage;
 
 	public Item toEntity() {
 		return Item.builder()

--- a/backend/src/main/java/codesquard/app/api/item/request/ItemModifyRequest.java
+++ b/backend/src/main/java/codesquard/app/api/item/request/ItemModifyRequest.java
@@ -4,7 +4,6 @@ import java.util.List;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Positive;
-import javax.validation.constraints.PositiveOrZero;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
@@ -20,7 +19,6 @@ import lombok.NoArgsConstructor;
 public class ItemModifyRequest {
 	@NotBlank(message = "제목은 필수 정보입니다.")
 	private String title;
-	@PositiveOrZero(message = "가격은 음수이면 안됩니다.")
 	private Long price;
 	private String content;
 	@NotBlank(message = "동네는 필수 정보입니다.")

--- a/backend/src/main/java/codesquard/app/domain/category/Category.java
+++ b/backend/src/main/java/codesquard/app/domain/category/Category.java
@@ -29,4 +29,9 @@ public class Category {
 		this.imageUrl = imageUrl;
 	}
 
+	@Override
+	public String toString() {
+		return String.format("%s, %s(id=%d, name=%s)", "카테고리", this.getClass().getSimpleName(), id, name);
+	}
+
 }

--- a/backend/src/main/java/codesquard/app/domain/image/Image.java
+++ b/backend/src/main/java/codesquard/app/domain/image/Image.java
@@ -3,6 +3,7 @@ package codesquard.app.domain.image;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.FetchType;
 import javax.persistence.GeneratedValue;
@@ -30,18 +31,29 @@ public class Image {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "item_id")
 	private Item item;
+	@Column(name = "thumnail", nullable = false)
+	private boolean thumnail;
 
-	public Image(String imageUrl, Item item) {
+	public Image(String imageUrl, Item item, boolean thumnail) {
 		this.imageUrl = imageUrl;
 		this.item = item;
+		this.thumnail = thumnail;
 	}
 
 	public static List<Image> createImages(List<String> imageUrls, Item item) {
 		List<Image> images = new ArrayList<>();
 		for (String imageUrl : imageUrls) {
-			images.add(new Image(imageUrl, item));
+			images.add(new Image(imageUrl, item, false));
 		}
 		return images;
+	}
+
+	public static Image thumnail(String imageUrl, Long itemId) {
+		return new Image(imageUrl, new Item(itemId), true);
+	}
+
+	public static Image basicImage(String imageUrl, Long itemId) {
+		return new Image(imageUrl, new Item(itemId), false);
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/image/Image.java
+++ b/backend/src/main/java/codesquard/app/domain/image/Image.java
@@ -31,7 +31,7 @@ public class Image {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "item_id")
 	private Item item;
-	@Column(name = "thumnail", nullable = false)
+	@Column(name = "thumbnail", nullable = false)
 	private boolean thumbnail;
 
 	public Image(String imageUrl, Item item, boolean thumbnail) {
@@ -48,7 +48,7 @@ public class Image {
 		return images;
 	}
 
-	public static Image thumnail(String imageUrl, Long itemId) {
+	public static Image thumbnail(String imageUrl, Long itemId) {
 		return new Image(imageUrl, new Item(itemId), true);
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/image/Image.java
+++ b/backend/src/main/java/codesquard/app/domain/image/Image.java
@@ -32,12 +32,12 @@ public class Image {
 	@JoinColumn(name = "item_id")
 	private Item item;
 	@Column(name = "thumnail", nullable = false)
-	private boolean thumnail;
+	private boolean thumbnail;
 
-	public Image(String imageUrl, Item item, boolean thumnail) {
+	public Image(String imageUrl, Item item, boolean thumbnail) {
 		this.imageUrl = imageUrl;
 		this.item = item;
-		this.thumnail = thumnail;
+		this.thumbnail = thumbnail;
 	}
 
 	public static List<Image> createImages(List<String> imageUrls, Item item) {

--- a/backend/src/main/java/codesquard/app/domain/image/Image.java
+++ b/backend/src/main/java/codesquard/app/domain/image/Image.java
@@ -52,10 +52,6 @@ public class Image {
 		return new Image(imageUrl, new Item(itemId), true);
 	}
 
-	public static Image basicImage(String imageUrl, Long itemId) {
-		return new Image(imageUrl, new Item(itemId), false);
-	}
-
 	@Override
 	public String toString() {
 		return String.format("%s, %s(id=%d, imageUrl=%s, item_id=%d)",

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -17,4 +17,11 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 		@Param("imageUrls") List<String> imageUrls);
 
 	int countImageByItemId(Long itemId);
+
+	@Modifying
+	@Query("update Image set thumnail = :thumnail where item.id = :itemId and imageUrl = :imageUrl")
+	int updateThumnailByItemIdAndImageUrl(
+		@Param("itemId") Long itemId,
+		@Param("imageUrl") String imageUrl,
+		@Param("thumnail") boolean thumnail);
 }

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -19,12 +19,12 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	int countImageByItemId(Long itemId);
 
 	@Modifying
-	@Query("update Image set thumnail = false where item.id = :itemId")
+	@Query("update Image set thumbnail = false where item.id = :itemId")
 	int updateAllThumnailIsFalseByItemId(@Param("itemId") Long itemId);
 
 	@Modifying
-	@Query("update Image set thumnail = :thumnail where item.id = :itemId and imageUrl = :imageUrl")
-	int updateThumnailByItemIdAndImageUrl(
+	@Query("update Image set thumbnail = :thumnail where item.id = :itemId and imageUrl = :imageUrl")
+	int updateThumbnailByItemIdAndImageUrl(
 		@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl,
 		@Param("thumnail") boolean thumnail);

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -23,9 +23,9 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	int updateAllThumnailIsFalseByItemId(@Param("itemId") Long itemId);
 
 	@Modifying
-	@Query("update Image set thumbnail = :thumnail where item.id = :itemId and imageUrl = :imageUrl")
+	@Query("update Image set thumbnail = :thumbnail where item.id = :itemId and imageUrl = :imageUrl")
 	int updateThumbnailByItemIdAndImageUrl(
 		@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl,
-		@Param("thumnail") boolean thumnail);
+		@Param("thumbnail") boolean thumbnail);
 }

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -19,8 +19,8 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	int countImageByItemId(Long itemId);
 
 	@Modifying
-	@Query("update Image set thumbnail = false where item.id = :itemId")
-	int updateAllThumnailIsFalseByItemId(@Param("itemId") Long itemId);
+	@Query("update Image set thumbnail = false where item.id = :itemId and thumbnail = true")
+	int updateThumnailToFalseByItemIdAndThumbnailIsTrue(@Param("itemId") Long itemId);
 
 	@Modifying
 	@Query("update Image set thumbnail = :thumbnail where item.id = :itemId and imageUrl = :imageUrl")

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -19,6 +19,10 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 	int countImageByItemId(Long itemId);
 
 	@Modifying
+	@Query("update Image set thumnail = false where item.id = :itemId")
+	int updateAllThumnailIsFalseByItemId(@Param("itemId") Long itemId);
+
+	@Modifying
 	@Query("update Image set thumnail = :thumnail where item.id = :itemId and imageUrl = :imageUrl")
 	int updateThumnailByItemIdAndImageUrl(
 		@Param("itemId") Long itemId,

--- a/backend/src/main/java/codesquard/app/domain/item/Item.java
+++ b/backend/src/main/java/codesquard/app/domain/item/Item.java
@@ -133,4 +133,11 @@ public class Item {
 			throw new RestApiException(ItemErrorCode.ITEM_FORBIDDEN);
 		}
 	}
+
+	public boolean equalThumnailImageUrl(String requestThumnailImage) {
+		if (thumbnailUrl == null) {
+			return false;
+		}
+		return thumbnailUrl.equals(requestThumnailImage);
+	}
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,6 +3,7 @@ spring:
     group:
       local: local, secret, s3
       dev: dev, secret, s3
+      test: test, secret, s3
     default: local
 
 ---
@@ -67,6 +68,33 @@ logging:
   level:
     codesquard: info
 
+---
+spring:
+  config:
+    activate:
+      on-profile: test
+  datasource:
+    url: ${db.local.datasource.url}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    username: ${db.local.datasource.username}
+    password: ${db.local.datasource.password}
+  jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      ddl-auto: create
+    properties:
+      hibernate:
+        format_sql: true
+        dialect: org.hibernate.dialect.MySQL8Dialect
+    defer-datasource-initialization: true
+    show-sql: true
+  redis:
+    host: localhost
+    port: 6379
+logging:
+  level:
+    codesquard: debug
 ---
 
 spring:

--- a/backend/src/main/resources/db/mysql/data.sql
+++ b/backend/src/main/resources/db/mysql/data.sql
@@ -28,4 +28,34 @@ LOAD DATA LOCAL INFILE 'src/main/resources/regions.csv'
     IGNORE 1 ROWS
     (@col1) set name = @col1;
 
+INSERT INTO member(avatar_url, email, login_id)
+VALUES ('https://nid.naver.com/user2/api/route?m=routePcProfileModification',
+        'dragonbead95@naver.com',
+        'bruni');
+
+INSERT INTO member_town(name, member_id, region_id)
+VALUES ('청운동', 1, 1);
+
+INSERT INTO item(chat_count,
+                 content,
+                 created_at,
+                 price,
+                 region,
+                 status,
+                 thumbnail_url,
+                 title,
+                 view_count,
+                 wish_count,
+                 category_id,
+                 member_id)
+VALUES (0, '롤러블레이드 팝니다', now(), 169000, '청운동', 'ON_SALE',
+        'https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
+        '롤러 블레이드', 0, 0, 1, 1);
+
+INSERT INTO image (image_url, thumnail, item_id)
+VALUES ('https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
+        true,
+        1);
+
+
 

--- a/backend/src/main/resources/db/mysql/data.sql
+++ b/backend/src/main/resources/db/mysql/data.sql
@@ -52,7 +52,7 @@ VALUES (0, '롤러블레이드 팝니다', now(), 169000, '청운동', 'ON_SALE'
         'https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
         '롤러 블레이드', 0, 0, 1, 1);
 
-INSERT INTO image (image_url, thumnail, item_id)
+INSERT INTO image (image_url, thumbnail, item_id)
 VALUES ('https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
         true,
         1);

--- a/backend/src/test/java/codesquard/app/api/category/CategoryQueryServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/category/CategoryQueryServiceTest.java
@@ -8,10 +8,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.category.response.CategoryListResponse;
 import codesquard.app.domain.category.CategoryRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class CategoryQueryServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/category/CategoryRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/category/CategoryRestControllerTest.java
@@ -13,12 +13,14 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import codesquard.app.ControllerTestSupport;
 import codesquard.app.api.category.response.CategoryListResponse;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = CategoryRestController.class)
 class CategoryRestControllerTest extends ControllerTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -31,6 +32,7 @@ import codesquard.app.domain.item.Item;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.oauth.support.Principal;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = ItemController.class)
 class ItemControllerTest extends ControllerTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -190,8 +190,8 @@ class ItemServiceTest {
 			.build();
 		Item saveItem = itemRepository.save(item);
 		List<Image> images = List.of(
-			Image.basicImage("imageUrlValue1", saveItem.getId()),
-			Image.basicImage("imageUrlValue2", saveItem.getId()));
+			new Image("imageUrlValue1", saveItem, false),
+			new Image("imageUrlValue2", saveItem, false));
 		List<Image> saveImages = imageRepository.saveAll(images);
 
 		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"),
@@ -268,8 +268,8 @@ class ItemServiceTest {
 			.build();
 		Item saveItem = itemRepository.save(item);
 		List<Image> images = List.of(
-			Image.basicImage("imageUrlValue1", saveItem.getId()),
-			Image.basicImage("imageUrlValue2", saveItem.getId()));
+			new Image("imageUrlValue1", saveItem, false),
+			new Image("imageUrlValue2", saveItem, false));
 		List<Image> saveImages = imageRepository.saveAll(images);
 
 		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"));
@@ -344,8 +344,8 @@ class ItemServiceTest {
 			.build();
 		Item saveItem = itemRepository.save(item);
 		List<Image> images = List.of(
-			Image.thumnail("imageUrlValue1", saveItem.getId()),
-			Image.basicImage("imageUrlValue2", saveItem.getId()));
+			new Image("imageUrlValue1", saveItem, true),
+			new Image("imageUrlValue2", saveItem, false));
 		List<Image> saveImages = imageRepository.saveAll(images);
 
 		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"));
@@ -435,8 +435,8 @@ class ItemServiceTest {
 		Item saveItem = itemRepository.save(item);
 
 		List<Image> images = List.of(
-			Image.basicImage("imageUrlValue1", saveItem.getId()),
-			Image.basicImage("imageUrlValue2", saveItem.getId()));
+			new Image("imageUrlValue1", saveItem, false),
+			new Image("imageUrlValue2", saveItem, false));
 		imageRepository.saveAll(images);
 
 		Wish wish = new Wish(member, item, now());

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -239,7 +239,7 @@ class ItemServiceTest {
 				.findAny()
 				.orElseThrow();
 			assertThat(thumnail)
-				.extracting("thumnail")
+				.extracting("thumbnail")
 				.isEqualTo(true);
 		});
 	}
@@ -315,7 +315,7 @@ class ItemServiceTest {
 				.findAny()
 				.orElseThrow();
 			assertThat(thumnail)
-				.extracting("thumnail")
+				.extracting("thumbnail")
 				.isEqualTo(true);
 		});
 	}
@@ -391,7 +391,7 @@ class ItemServiceTest {
 				.findAny()
 				.orElseThrow();
 			assertThat(thumnail)
-				.extracting("thumnail")
+				.extracting("thumbnail")
 				.isEqualTo(true);
 		});
 	}

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.multipart.MultipartFile;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -57,6 +58,7 @@ import codesquard.app.domain.wish.Wish;
 import codesquard.app.domain.wish.WishRepository;
 import codesquard.support.SupportRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class ItemServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -164,7 +164,7 @@ class ItemServiceTest {
 			() -> assertThat(all.getPaging().getNextCursor()).isEqualTo(item.getId()));
 	}
 
-	@DisplayName("회원은 상품의 정보를 수정한다")
+	@DisplayName("회원은 상품 정보 수정시 기존 썸네일 이미지를 두고 수정한다")
 	@Test
 	public void modifyItem() throws IOException {
 		// given
@@ -184,20 +184,101 @@ class ItemServiceTest {
 			.wishCount(0L)
 			.viewCount(0L)
 			.chatCount(0L)
+			.thumbnailUrl("imageUrlValue1")
 			.member(member)
 			.category(category)
 			.build();
 		Item saveItem = itemRepository.save(item);
 		List<Image> images = List.of(
-			new Image("imageUrlValue1", new Item(saveItem.getId())),
-			new Image("imageUrlValue2", new Item(saveItem.getId())));
+			Image.basicImage("imageUrlValue1", saveItem.getId()),
+			Image.basicImage("imageUrlValue2", saveItem.getId()));
 		List<Image> saveImages = imageRepository.saveAll(images);
 
 		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"),
 			createMultipartFile("roller_blade.jpeg"));
 		List<String> deleteImageUrls = saveImages.stream()
 			.map(Image::getImageUrl)
+			.filter(imageUrl -> imageUrl.equals("imageUrlValue2"))
 			.collect(Collectors.toUnmodifiableList());
+		MultipartFile thumnailFile = null;
+
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("title", "빈티지 롤러 스케이트");
+		requestBody.put("price", 169000);
+		requestBody.put("content", "내용");
+		requestBody.put("region", "가락동");
+		requestBody.put("status", "판매중");
+		requestBody.put("categoryId", category.getId());
+		requestBody.put("categoryName", category.getName());
+		requestBody.put("deleteImageUrls", deleteImageUrls);
+		requestBody.put("thumnailImage", "imageUrlValue1");
+		ItemModifyRequest request = objectMapper.readValue(objectMapper.writeValueAsString(requestBody),
+			ItemModifyRequest.class);
+
+		given(imageUploader.uploadImageToS3(any(), any()))
+			.willReturn("imageUrlValue3", "imageUrlValue4");
+
+		// when
+		itemService.modifyItem(saveItem.getId(), request, addImages, thumnailFile, Principal.from(member));
+
+		// then
+		assertAll(() -> {
+			Item modifiedItem = itemRepository.findById(saveItem.getId()).orElseThrow();
+			assertThat(modifiedItem)
+				.extracting("title", "content", "price", "status", "region", "thumbnailUrl")
+				.contains(request.getTitle(), request.getContent(), request.getPrice(), request.getStatus(),
+					request.getRegion(), request.getThumnailImage());
+
+			List<Image> modifiedImages = imageRepository.findAllByItemId(saveItem.getId());
+			assertThat(modifiedImages).hasSize(3);
+
+			Image thumnail = modifiedImages.stream()
+				.filter(image -> image.getImageUrl().equals("imageUrlValue1"))
+				.findAny()
+				.orElseThrow();
+			assertThat(thumnail)
+				.extracting("thumnail")
+				.isEqualTo(true);
+		});
+	}
+
+	@DisplayName("회원은 상품 정보 수정시 새로운 썸네일 이미지를 두고 수정한다")
+	@Test
+	public void modifyItemWithNewThumnail() throws IOException {
+		// given
+		Category category = categoryRepository.save(findByName("스포츠/레저"));
+		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
+
+		Region region = regionRepository.save(createRegion("서울 송파구 가락동"));
+		memberTownRepository.save(new MemberTown(region.getShortAddress(), member, region));
+
+		Item item = Item.builder()
+			.title("빈티지 롤러 블레이드")
+			.content("어린시절 추억의향수를 불러 일으키는 롤러 스케이트입니다.")
+			.price(200000L)
+			.status(ON_SALE)
+			.region("가락동")
+			.createdAt(now())
+			.wishCount(0L)
+			.viewCount(0L)
+			.chatCount(0L)
+			.thumbnailUrl("imageUrlValue1")
+			.member(member)
+			.category(category)
+			.build();
+		Item saveItem = itemRepository.save(item);
+		List<Image> images = List.of(
+			Image.basicImage("imageUrlValue1", saveItem.getId()),
+			Image.basicImage("imageUrlValue2", saveItem.getId()));
+		List<Image> saveImages = imageRepository.saveAll(images);
+
+		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"));
+		List<String> deleteImageUrls = saveImages.stream()
+			.map(Image::getImageUrl)
+			.filter(imageUrl -> imageUrl.equals("imageUrlValue2"))
+			.collect(Collectors.toUnmodifiableList());
+		MultipartFile thumnailFile = createMultipartFile("roller_blade.jpeg");
+
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("title", "빈티지 롤러 스케이트");
 		requestBody.put("price", 169000);
@@ -211,17 +292,105 @@ class ItemServiceTest {
 			ItemModifyRequest.class);
 
 		given(imageUploader.uploadImageToS3(any(), any()))
-			.willReturn("http://s3_image1.com", "http://s3_image2.com");
+			.willReturn("imageUrlValue3", "imageUrlValue4");
+
 		// when
-		itemService.modifyItem(saveItem.getId(), request, addImages, Principal.from(member));
+		itemService.modifyItem(saveItem.getId(), request, addImages, thumnailFile, Principal.from(member));
+
 		// then
-		Item modifiedItem = itemRepository.findById(saveItem.getId()).orElseThrow();
 		assertAll(() -> {
+			Item modifiedItem = itemRepository.findById(saveItem.getId()).orElseThrow();
 			assertThat(modifiedItem)
-				.extracting("title", "content", "price", "status", "region")
+				.extracting("title", "content", "price", "status", "region", "thumbnailUrl")
 				.contains(request.getTitle(), request.getContent(), request.getPrice(), request.getStatus(),
-					request.getRegion());
-			assertThat(images).hasSize(2);
+					request.getRegion(), "imageUrlValue4");
+
+			List<Image> modifiedImages = imageRepository.findAllByItemId(saveItem.getId());
+			assertThat(modifiedImages).hasSize(3);
+
+			Image thumnail = modifiedImages.stream()
+				.filter(image -> image.getImageUrl().equals("imageUrlValue4"))
+				.findAny()
+				.orElseThrow();
+			assertThat(thumnail)
+				.extracting("thumnail")
+				.isEqualTo(true);
+		});
+	}
+
+	@DisplayName("회원은 상품 정보 수정시 썸네일 이미지를 그대로 두고 수정한다")
+	@Test
+	public void modifyItemWithNonChange() throws IOException {
+		// given
+		Category category = categoryRepository.save(findByName("스포츠/레저"));
+		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
+
+		Region region = regionRepository.save(createRegion("서울 송파구 가락동"));
+		memberTownRepository.save(new MemberTown(region.getShortAddress(), member, region));
+
+		Item item = Item.builder()
+			.title("빈티지 롤러 블레이드")
+			.content("어린시절 추억의향수를 불러 일으키는 롤러 스케이트입니다.")
+			.price(200000L)
+			.status(ON_SALE)
+			.region("가락동")
+			.createdAt(now())
+			.wishCount(0L)
+			.viewCount(0L)
+			.chatCount(0L)
+			.thumbnailUrl("imageUrlValue1")
+			.member(member)
+			.category(category)
+			.build();
+		Item saveItem = itemRepository.save(item);
+		List<Image> images = List.of(
+			Image.thumnail("imageUrlValue1", saveItem.getId()),
+			Image.basicImage("imageUrlValue2", saveItem.getId()));
+		List<Image> saveImages = imageRepository.saveAll(images);
+
+		List<MultipartFile> addImages = List.of(createMultipartFile("cat.png"));
+		List<String> deleteImageUrls = saveImages.stream()
+			.map(Image::getImageUrl)
+			.filter(imageUrl -> imageUrl.equals("imageUrlValue2"))
+			.collect(Collectors.toUnmodifiableList());
+		MultipartFile thumnailFile = null;
+
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("title", "빈티지 롤러 스케이트");
+		requestBody.put("price", 169000);
+		requestBody.put("content", "내용");
+		requestBody.put("region", "가락동");
+		requestBody.put("status", "판매중");
+		requestBody.put("categoryId", category.getId());
+		requestBody.put("categoryName", category.getName());
+		requestBody.put("deleteImageUrls", deleteImageUrls);
+		ItemModifyRequest request = objectMapper.readValue(objectMapper.writeValueAsString(requestBody),
+			ItemModifyRequest.class);
+
+		given(imageUploader.uploadImageToS3(any(), any()))
+			.willReturn("imageUrlValue3");
+
+		// when
+		itemService.modifyItem(saveItem.getId(), request, addImages, thumnailFile, Principal.from(member));
+
+		// then
+		assertAll(() -> {
+			Item modifiedItem = itemRepository.findById(saveItem.getId()).orElseThrow();
+			assertThat(modifiedItem)
+				.extracting("title", "content", "price", "status", "region", "thumbnailUrl")
+				.contains(request.getTitle(), request.getContent(), request.getPrice(), request.getStatus(),
+					request.getRegion(), "imageUrlValue1");
+
+			List<Image> modifiedImages = imageRepository.findAllByItemId(saveItem.getId());
+			assertThat(modifiedImages).hasSize(2);
+
+			Image thumnail = modifiedImages.stream()
+				.filter(image -> image.getImageUrl().equals("imageUrlValue1"))
+				.findAny()
+				.orElseThrow();
+			assertThat(thumnail)
+				.extracting("thumnail")
+				.isEqualTo(true);
 		});
 	}
 
@@ -266,8 +435,8 @@ class ItemServiceTest {
 		Item saveItem = itemRepository.save(item);
 
 		List<Image> images = List.of(
-			new Image("imageUrlValue1", new Item(saveItem.getId())),
-			new Image("imageUrlValue2", new Item(saveItem.getId())));
+			Image.basicImage("imageUrlValue1", saveItem.getId()),
+			Image.basicImage("imageUrlValue2", saveItem.getId()));
 		imageRepository.saveAll(images);
 
 		Wish wish = new Wish(member, item, now());

--- a/backend/src/test/java/codesquard/app/api/member/MemberServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/member/MemberServiceTest.java
@@ -17,12 +17,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.image.ImageUploader;
 import codesquard.app.domain.jwt.JwtProvider;
 import codesquard.app.domain.member.Member;
 import codesquard.support.SupportRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest(webEnvironment = WebEnvironment.DEFINED_PORT)
 class MemberServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/member/unit/MemberServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/member/unit/MemberServiceTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.IntegrationTestSupport;
 import codesquard.app.api.image.ImageUploader;
@@ -19,6 +20,7 @@ import codesquard.app.api.member.MemberService;
 import codesquard.app.domain.member.Member;
 import codesquard.support.SupportRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MemberServiceTest extends IntegrationTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
@@ -18,6 +18,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -31,6 +32,7 @@ import codesquard.app.domain.membertown.MemberTown;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.region.Region;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = MemberTownRestController.class)
 class MemberTownRestControllerTest extends ControllerTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -31,6 +32,7 @@ import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.region.Region;
 import codesquard.app.domain.region.RegionRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MemberTownServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -25,6 +25,7 @@ import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -39,6 +40,7 @@ import codesquard.app.filter.JwtAuthorizationFilter;
 import codesquard.app.filter.LogoutFilter;
 import codesquard.app.interceptor.LogoutInterceptor;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = OauthRestController.class)
 class OauthRestControllerTest extends ControllerTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -1,6 +1,7 @@
 package codesquard.app.api.oauth;
 
 import static codesquard.app.MemberTestSupport.*;
+import static codesquard.app.RegionTestSupport.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.BDDMockito.*;
@@ -95,6 +96,7 @@ class OauthServiceTest {
 	@Test
 	public void signUp() throws IOException {
 		// given
+		regionRepository.save(createRegion("서울 송파구 가락동"));
 		List<Long> addressIds = getAddressIds(regionRepository.findAllByNameIn(List.of("서울 송파구 가락동")));
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("loginId", "23Yong");
@@ -287,6 +289,7 @@ class OauthServiceTest {
 	@Test
 	public void signUpWhenDuplicateLoginId() throws IOException {
 		// given
+		regionRepository.save(createRegion("서울 송파구 가락동"));
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong1234@gmail.com", "23Yong"));
 
 		Region region = regionRepository.findAllByNameIn(List.of("서울 송파구 가락동")).stream().findAny().orElseThrow();
@@ -408,7 +411,7 @@ class OauthServiceTest {
 	public void logoutWithExpireAccessToken() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
-		LocalDateTime now = LocalDateTime.now().minusMinutes(5);
+		LocalDateTime now = LocalDateTime.now().minusDays(1);
 		Jwt jwt = jwtProvider.createJwtBasedOnMember(member, now);
 
 		Map<String, Object> requestBody = new HashMap<>();

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -21,6 +21,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.mock.web.MockMultipartFile;
+import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,6 +51,7 @@ import codesquard.app.domain.oauth.repository.OauthClientRepository;
 import codesquard.app.domain.region.Region;
 import codesquard.app.domain.region.RegionRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class OauthServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/oauth/properties/OauthPropertiesTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/properties/OauthPropertiesTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.domain.oauth.client.OauthClient;
 import codesquard.app.domain.oauth.properties.OauthProperties;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public class OauthPropertiesTest {
 

--- a/backend/src/test/java/codesquard/app/api/region/RegionQueryServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionQueryServiceTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.region.response.RegionListResponse;
 import codesquard.app.domain.region.RegionRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class RegionQueryServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -22,6 +23,7 @@ import codesquard.app.ControllerTestSupport;
 import codesquard.app.api.region.response.RegionItemResponse;
 import codesquard.app.api.region.response.RegionListResponse;
 
+@ActiveProfiles("test")
 @WebMvcTest(controllers = RegionRestController.class)
 class RegionRestControllerTest extends ControllerTestSupport {
 

--- a/backend/src/test/java/codesquard/app/api/sales/SalesItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/sales/SalesItemServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.item.request.ItemRegisterRequest;
 import codesquard.app.api.item.response.ItemResponses;
@@ -19,6 +20,7 @@ import codesquard.app.domain.member.MemberRepository;
 import codesquard.app.domain.sales.SalesStatus;
 import codesquard.support.SupportRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class SalesItemServiceTest {
 

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.item.request.ItemRegisterRequest;
 import codesquard.app.api.item.response.ItemResponse;
@@ -26,6 +27,7 @@ import codesquard.app.domain.wish.WishRepository;
 import codesquard.app.domain.wish.WishStatus;
 import codesquard.support.SupportRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class WishItemServiceTest {
 

--- a/backend/src/test/java/codesquard/app/domain/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/codesquard/app/domain/jwt/JwtProviderTest.java
@@ -9,10 +9,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.member.MemberRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class JwtProviderTest {
 

--- a/backend/src/test/java/codesquard/app/domain/member/AuthenticateMemberTest.java
+++ b/backend/src/test/java/codesquard/app/domain/member/AuthenticateMemberTest.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.AssertionsForClassTypes.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 class AuthenticateMemberTest {
 
 	@DisplayName("Member 엔티티를 가지고 AuthenticateUser 객체를 생성한다")

--- a/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.api.errors.errorcode.MemberErrorCode;
 import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.RestApiException;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class MemberRepositoryTest {
 

--- a/backend/src/test/java/codesquard/app/domain/oauth/InMemoryOauthClientRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/oauth/InMemoryOauthClientRepositoryTest.java
@@ -7,10 +7,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.domain.oauth.client.OauthClient;
 import codesquard.app.domain.oauth.repository.OauthClientRepository;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class InMemoryOauthClientRepositoryTest {
 

--- a/backend/src/test/java/codesquard/app/domain/region/RegionPaginationRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/region/RegionPaginationRepositoryTest.java
@@ -12,9 +12,11 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
+import org.springframework.test.context.ActiveProfiles;
 
 import codesquard.app.RegionTestSupport;
 
+@ActiveProfiles("test")
 @SpringBootTest
 class RegionPaginationRepositoryTest {
 


### PR DESCRIPTION
## 구현한 것

- 상품 게시글 수정시 썸네일에 대한 로직을 개선하였습니다. 기존 썸네일 로직은 이미지 추가 및 제거하고 이미지를 조회한 다음에 0번째 이미지를 썸네일 url로 설정하였습니다. 변경된 부분은 클라이언트로부터 썸네일 정보를 받아서 처리하도록 변경하였습니다.
- thumnailImage 입력형식을 추가하여 파일이 있는 경우 해당 파일을 대상으로 썸네일로써 저장합니다. 
- 만약 requestBody와 멀티파트 thumnailImage가 둘다 값이 있는 경우 멀티파트 폼 썸네일 파일을 우선시합니다.

## 핵심코드
```java

	private String updateThumnail(Item item, MultipartFile thumnailFile, String thumnailUrl) {
		if (!thumnailFile.isEmpty()) {
			String thumnail = updateNewThumnail(item.getId(), thumnailFile);
			return updateThumnail(thumnail, item);
		}
		if (thumnailUrl != null) {
			return updateThumnail(thumnailUrl, item);
		}
		return item.getThumbnailUrl();
	}

	private String updateNewThumnail(Long itemId, MultipartFile thumnailFile) {
		String thumnailImageUrl = imageService.uploadImage(thumnailFile);
		log.debug("썸네일 이미지 S3 업로드 결과 : thumnailImageUrl={}", thumnailImageUrl);

		Image thumnail = imageRepository.save(Image.thumnail(thumnailImageUrl, itemId));
		log.debug("썸네일 이미지 테이블 저장 결과 : image={}", thumnail);
		return thumnailImageUrl;
	}

	private String updateThumnail(String changeThumnail, Item item) {
		if (changeThumnail == null) {
			return null;
		}

		int result = imageRepository.updateAllThumnailIsFalseByItemId(item.getId());
		log.debug("기존 이미지 썸네일 표시 변경 결과 : result={}", result);

		result = imageRepository.updateThumnailByItemIdAndImageUrl(item.getId(), changeThumnail, true);
		log.debug("요청 이미지 썸네일 표시 변경 결과 : result={}", result);

		return changeThumnail;
	}

```