### PR TITLE
[feat] 회원의 동네 선택 API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
@@ -11,6 +11,7 @@ public enum MemberTownErrorCode implements ErrorCode {
 	MINIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "동네는 최소 1개 이상 선택해야 해요. 새로운 동네를 등록한 후 삭제해주세요."),
 	ALREADY_ADDRESS_NAME(HttpStatus.CONFLICT, "이미 존재하는 동네입니다."),
 	UNREGISTERED_ADDRESS_TO_REMOVE(HttpStatus.BAD_REQUEST, "등록되지 않은 동네를 삭제할 수 없습니다."),
+	NOT_SELECT_UNREGISTERED_MEMBER_TOWN(HttpStatus.BAD_REQUEST, "회원이 등록한 동네만 선택할 수 있습니다."),
 	FAIL_REMOVE_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "동네 삭제를 실패하였습니다.");
 
 	private final HttpStatus httpStatus;

--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,5 +76,11 @@ public class ItemController {
 	public ApiResponse<Void> modifyItemStatus(@PathVariable Long itemId, @RequestBody ItemStatusModifyRequest request) {
 		itemService.findById(itemId, request.getStatus());
 		return ApiResponse.ok("상품 상태 변경에 성공하였습니다.", null);
+	}
+
+	@DeleteMapping("/{itemId}")
+	public ApiResponse<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
+		itemService.deleteItem(itemId, principal);
+		return ApiResponse.ok("상품 삭제가 완료되었습니다.", null);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -20,6 +20,7 @@ import codesquard.app.api.item.response.ItemResponse;
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.domain.category.Category;
 import codesquard.app.domain.category.CategoryRepository;
+import codesquard.app.domain.chat.ChatRoomRepository;
 import codesquard.app.domain.image.Image;
 import codesquard.app.domain.image.ImageRepository;
 import codesquard.app.domain.item.Item;
@@ -29,6 +30,7 @@ import codesquard.app.domain.item.ItemStatus;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.pagination.PaginationUtils;
+import codesquard.app.domain.wish.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -43,6 +45,8 @@ public class ItemService {
 	private final ImageService imageService;
 	private final CategoryRepository categoryRepository;
 	private final ItemPaginationRepository itemPaginationRepository;
+	private final WishRepository wishRepository;
+	private final ChatRoomRepository chatRoomRepository;
 
 	@Transactional
 	public void register(ItemRegisterRequest request, List<MultipartFile> itemImage, Long memberId) {
@@ -169,5 +173,25 @@ public class ItemService {
 	private Item findItemBy(Long itemId) {
 		return itemRepository.findById(itemId)
 			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
+	}
+
+	@Transactional
+	public void deleteItem(Long itemId, Principal writer) {
+		Item item = findItemBy(itemId);
+		item.validateSeller(writer.getMemberId());
+
+		List<Image> images = imageRepository.findAllByItemId(itemId);
+		images.stream()
+			.map(Image::getImageUrl)
+			.forEach(imageService::deleteImage);
+
+		deleteAllRelatedItem(itemId);
+	}
+
+	private void deleteAllRelatedItem(Long itemId) {
+		imageRepository.deleteByItemId(itemId);
+		wishRepository.deleteByItemId(itemId);
+		chatRoomRepository.deleteByItemId(itemId);
+		itemRepository.deleteById(itemId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownRestController.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownRestController.java
@@ -5,6 +5,7 @@ import javax.validation.Valid;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.membertown.request.MemberTownAddRequest;
 import codesquard.app.api.membertown.request.MemberTownRemoveRequest;
+import codesquard.app.api.region.request.RegionSelectionRequest;
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
@@ -39,5 +41,13 @@ public class MemberTownRestController {
 		@Valid @RequestBody MemberTownRemoveRequest request) {
 		memberTownService.removeMemberTown(principal, request);
 		return ApiResponse.ok("동네 삭제에 성공하였습니다.", null);
+	}
+
+	@PutMapping
+	public ApiResponse<Void> selectRegion(
+		@Valid @RequestBody RegionSelectionRequest request,
+		@AuthPrincipal Principal principal) {
+		memberTownService.selectRegion(request, principal);
+		return ApiResponse.ok("지역 선택을 완료하였습니다.", null);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
@@ -6,12 +6,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.MemberTownErrorCode;
 import codesquard.app.api.errors.errorcode.RegionErrorCode;
 import codesquard.app.api.errors.exception.RestApiException;
 import codesquard.app.api.membertown.request.MemberTownAddRequest;
 import codesquard.app.api.membertown.request.MemberTownRemoveRequest;
 import codesquard.app.api.membertown.response.MemberAddRegionResponse;
 import codesquard.app.api.membertown.response.MemberTownRemoveResponse;
+import codesquard.app.api.region.request.RegionSelectionRequest;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.member.MemberRepository;
 import codesquard.app.domain.membertown.MemberTown;
@@ -68,5 +70,31 @@ public class MemberTownService {
 	private Member findMemberBy(Principal principal) {
 		return memberRepository.findById(principal.getMemberId())
 			.orElseThrow(() -> new RestApiException(MemberErrorCode.NOT_FOUND_MEMBER));
+	}
+
+	@Transactional
+	public void selectRegion(RegionSelectionRequest request, Principal principal) {
+		validateExistRegion(request.getSelectedAddressId());
+		validateRegisteredMemberTown(request.getSelectedAddressId(), principal.getMemberId());
+
+		// 기존 선택된 회원 동네 선택을 false로 변경합니다.
+		int result = memberTownRepository.changeIsSelectToFalse(principal.getMemberId());
+		log.debug("지역 선택 해제 결과 : result={}", result);
+
+		// 새로 선택한 회원 동네 지역을 true로 변경한다
+		result = memberTownRepository.changeIsSelectToTrue(request.getSelectedAddressId(), principal.getMemberId());
+		log.debug("지역 선택 활성화 결과 : result={}", result);
+	}
+
+	private void validateRegisteredMemberTown(Long regionId, Long memberId) {
+		if (memberTownRepository.findMemberTownByMemberIdAndRegionId(memberId, regionId).isEmpty()) {
+			throw new RestApiException(MemberTownErrorCode.NOT_SELECT_UNREGISTERED_MEMBER_TOWN);
+		}
+	}
+
+	private void validateExistRegion(Long regionId) {
+		if (regionRepository.findById(regionId).isEmpty()) {
+			throw new RestApiException(RegionErrorCode.NOT_FOUND_REGION);
+		}
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/region/RegionRestController.java
+++ b/backend/src/main/java/codesquard/app/api/region/RegionRestController.java
@@ -14,13 +14,13 @@ import lombok.RequiredArgsConstructor;
 @RestController
 public class RegionRestController {
 
-	private final RegionQueryService regionQueryService;
+	private final RegionService regionService;
 
 	@GetMapping
 	public ApiResponse<RegionListResponse> findAll(
 		@RequestParam(value = "size", defaultValue = "10", required = false) int size,
 		@RequestParam(value = "cursor", required = false) Long cursor,
 		@RequestParam(value = "region", required = false) String region) {
-		return ApiResponse.ok("주소 목록 조회에 성공하였습니다.", regionQueryService.searchBySlice(size, cursor, region));
+		return ApiResponse.ok("주소 목록 조회에 성공하였습니다.", regionService.searchBySlice(size, cursor, region));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/region/RegionService.java
+++ b/backend/src/main/java/codesquard/app/api/region/RegionService.java
@@ -18,7 +18,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
-public class RegionQueryService {
+public class RegionService {
 
 	private final RegionPaginationRepository regionPaginationRepository;
 

--- a/backend/src/main/java/codesquard/app/api/region/RegionService.java
+++ b/backend/src/main/java/codesquard/app/api/region/RegionService.java
@@ -11,16 +11,22 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codesquard.app.api.region.response.RegionItemResponse;
 import codesquard.app.api.region.response.RegionListResponse;
+import codesquard.app.domain.membertown.MemberTownRepository;
 import codesquard.app.domain.region.Region;
 import codesquard.app.domain.region.RegionPaginationRepository;
+import codesquard.app.domain.region.RegionRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class RegionService {
 
 	private final RegionPaginationRepository regionPaginationRepository;
+	private final MemberTownRepository memberTownRepository;
+	private final RegionRepository regionRepository;
 
 	public RegionListResponse searchBySlice(int size, Long cursor, String region) {
 		Pageable pageable = PageRequest.ofSize(size);

--- a/backend/src/main/java/codesquard/app/api/region/request/RegionSelectionRequest.java
+++ b/backend/src/main/java/codesquard/app/api/region/request/RegionSelectionRequest.java
@@ -9,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class RegionSelectionRequest {
+	
 	@NotNull(message = "지역 등록번호는 필수 정보입니다.")
 	private Long selectedAddressId;
 }

--- a/backend/src/main/java/codesquard/app/api/region/request/RegionSelectionRequest.java
+++ b/backend/src/main/java/codesquard/app/api/region/request/RegionSelectionRequest.java
@@ -1,0 +1,14 @@
+package codesquard.app.api.region.request;
+
+import javax.validation.constraints.NotNull;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class RegionSelectionRequest {
+	@NotNull(message = "지역 등록번호는 필수 정보입니다.")
+	private Long selectedAddressId;
+}

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 	List<ChatRoom> findAllByItemId(Long itemId);
+
+	int deleteByItemId(Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -28,4 +28,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 		@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl,
 		@Param("thumbnail") boolean thumbnail);
+
+	int deleteByItemId(Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
@@ -4,13 +4,27 @@ import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface MemberTownRepository extends JpaRepository<MemberTown, Long> {
-	int countMemberTownById(Long id);
 
 	List<MemberTown> findAllByMemberId(Long memberId);
+
+	Optional<MemberTown> findMemberTownByMemberIdAndRegionId(Long memberId, Long regionId);
 
 	Optional<MemberTown> findMemberTownByMemberIdAndName(Long memberId, String name);
 
 	void deleteMemberTownByMemberIdAndRegionId(Long memberId, Long regionId);
+
+	@Modifying
+	@Query("update MemberTown memberTown set memberTown.isSelected = false where memberTown.isSelected = true and memberTown.member.id = :memberId")
+	int changeIsSelectToFalse(@Param("memberId") Long memberId);
+
+	@Modifying
+	@Query("update MemberTown memberTown set memberTown.isSelected = true where memberTown.region.id = :regionId and memberTown.member.id = :memberId")
+	int changeIsSelectToTrue(
+		@Param("regionId") Long regionId,
+		@Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/codesquard/app/domain/region/RegionRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/region/RegionRepository.java
@@ -5,7 +5,6 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface RegionRepository extends JpaRepository<Region, Long> {
-	boolean existsRegionByName(String name);
 
 	List<Region> findAllByNameIn(List<String> names);
 }

--- a/backend/src/test/java/codesquard/app/IntegrationTestSupport.java
+++ b/backend/src/test/java/codesquard/app/IntegrationTestSupport.java
@@ -9,7 +9,7 @@ import codesquard.app.api.item.ItemService;
 import codesquard.app.api.member.MemberService;
 import codesquard.app.api.membertown.MemberTownService;
 import codesquard.app.api.oauth.OauthService;
-import codesquard.app.api.region.RegionQueryService;
+import codesquard.app.api.region.RegionService;
 import codesquard.app.api.sales.SalesItemService;
 import codesquard.app.domain.category.CategoryRepository;
 import codesquard.app.domain.chat.ChatLogRepository;
@@ -63,7 +63,7 @@ public abstract class IntegrationTestSupport {
 	protected RegionRepository regionRepository;
 
 	@Autowired
-	protected RegionQueryService regionQueryService;
+	protected RegionService regionService;
 
 	@Autowired
 	protected MemberService memberService;

--- a/backend/src/test/java/codesquard/app/MemberTownTestSupport.java
+++ b/backend/src/test/java/codesquard/app/MemberTownTestSupport.java
@@ -1,0 +1,11 @@
+package codesquard.app;
+
+import codesquard.app.domain.member.Member;
+import codesquard.app.domain.membertown.MemberTown;
+import codesquard.app.domain.region.Region;
+
+public class MemberTownTestSupport {
+	public static MemberTown createMemberTown(Member member, Region region, boolean isSelected) {
+		return new MemberTown(region.getShortAddress(), member, region, isSelected);
+	}
+}

--- a/backend/src/test/java/codesquard/app/MemberTownTestSupport.java
+++ b/backend/src/test/java/codesquard/app/MemberTownTestSupport.java
@@ -5,6 +5,7 @@ import codesquard.app.domain.membertown.MemberTown;
 import codesquard.app.domain.region.Region;
 
 public class MemberTownTestSupport {
+	
 	public static MemberTown createMemberTown(Member member, Region region, boolean isSelected) {
 		return new MemberTown(region.getShortAddress(), member, region, isSelected);
 	}

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -156,5 +157,20 @@ class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("statusCode").value(equalTo(404)))
 			.andExpect(jsonPath("message").value(equalTo("상품을 찾을 수 없습니다.")))
 			.andExpect(jsonPath("data").value(equalTo(null)));
+	}
+
+	@DisplayName("상품을 삭제합니다.")
+	@Test
+	public void deleteItem() throws Exception {
+		// given
+		willDoNothing().given(itemService).deleteItem(
+			ArgumentMatchers.anyLong(),
+			ArgumentMatchers.any(Principal.class));
+
+		// when & then
+		mockMvc.perform(delete("/api/items/1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("statusCode").value(equalTo(200)))
+			.andExpect(jsonPath("message").value(equalTo("상품 삭제가 완료되었습니다.")));
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
@@ -27,6 +27,7 @@ import codesquard.app.api.membertown.request.MemberTownAddRequest;
 import codesquard.app.api.membertown.request.MemberTownRemoveRequest;
 import codesquard.app.api.membertown.response.MemberAddRegionResponse;
 import codesquard.app.api.membertown.response.MemberTownRemoveResponse;
+import codesquard.app.api.region.request.RegionSelectionRequest;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.membertown.MemberTown;
 import codesquard.app.domain.oauth.support.Principal;
@@ -119,5 +120,41 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("data[*].field").value(containsInAnyOrder("addressId")))
 			.andExpect(jsonPath("data[*].defaultMessage")
 				.value(containsInAnyOrder("주소 정보는 필수 정보입니다.")));
+	}
+
+	@DisplayName("회원이 지역 등록번호를 가지고 회원의 동네를 선택한다")
+	@Test
+	public void selectRegion() throws Exception {
+		// given
+		Map<String, Object> requestBody = Map.of("selectedAddressId", 1L);
+
+		willDoNothing().given(memberTownService).selectRegion(
+			ArgumentMatchers.any(RegionSelectionRequest.class),
+			ArgumentMatchers.any(Principal.class));
+		// when & then
+		mockMvc.perform(put("/api/regions")
+				.content(objectMapper.writeValueAsString(requestBody))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("statusCode").value(equalTo(200)))
+			.andExpect(jsonPath("message").value(equalTo("지역 선택을 완료하였습니다.")));
+	}
+
+	@DisplayName("회원이 지역 등록번호를 null을 전달하여 회원의 동네를 선택할 수 없다")
+	@Test
+	public void selectRegionWithSelectedAddressIdIsNull() throws Exception {
+		// given
+		Map<String, Object> requestBody = new HashMap<>();
+		requestBody.put("selectedAddressId", null);
+
+		// when & then
+		mockMvc.perform(put("/api/regions")
+				.content(objectMapper.writeValueAsString(requestBody))
+				.contentType(MediaType.APPLICATION_JSON))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("statusCode").value(equalTo(400)))
+			.andExpect(jsonPath("message").value(equalTo("유효하지 않은 입력형식입니다.")))
+			.andExpect(jsonPath("data[0].field").value(equalTo("selectedAddressId")))
+			.andExpect(jsonPath("data[0].defaultMessage").value(equalTo("지역 등록번호는 필수 정보입니다.")));
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
@@ -33,7 +33,7 @@ class RegionRestControllerTest extends ControllerTestSupport {
 	private RegionRestController regionRestController;
 
 	@MockBean
-	private RegionQueryService regionQueryService;
+	private RegionService regionService;
 
 	@BeforeEach
 	public void setup() {
@@ -52,7 +52,7 @@ class RegionRestControllerTest extends ControllerTestSupport {
 		RegionItemResponse region3 = createRegionItemResponse("경기 부천시 범박동");
 		RegionListResponse response = new RegionListResponse(List.of(region1, region2, region3), true, 3L);
 
-		given(regionQueryService.searchBySlice(anyInt(), anyLong(), anyString()))
+		given(regionService.searchBySlice(anyInt(), anyLong(), anyString()))
 			.willReturn(response);
 
 		// when & then

--- a/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
@@ -11,7 +11,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 import codesquard.app.api.region.response.RegionListResponse;
+import codesquard.app.domain.member.MemberRepository;
+import codesquard.app.domain.membertown.MemberTownRepository;
 import codesquard.app.domain.region.RegionRepository;
 
 @ActiveProfiles("test")
@@ -24,9 +28,20 @@ class RegionServiceTest {
 	@Autowired
 	private RegionService regionService;
 
+	@Autowired
+	private MemberRepository memberRepository;
+
+	@Autowired
+	private MemberTownRepository memberTownRepository;
+
+	@Autowired
+	private ObjectMapper objectMapper;
+
 	@AfterEach
 	void tearDown() {
 		regionRepository.deleteAllInBatch();
+		memberTownRepository.deleteAllInBatch();
+		memberRepository.deleteAllInBatch();
 	}
 
 	@DisplayName("주소 목록을 처음 조회할때 10개가 조회한다")

--- a/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
@@ -16,13 +16,13 @@ import codesquard.app.domain.region.RegionRepository;
 
 @ActiveProfiles("test")
 @SpringBootTest
-class RegionQueryServiceTest {
+class RegionServiceTest {
 
 	@Autowired
 	private RegionRepository regionRepository;
 
 	@Autowired
-	private RegionQueryService regionQueryService;
+	private RegionService regionService;
 
 	@AfterEach
 	void tearDown() {
@@ -39,7 +39,7 @@ class RegionQueryServiceTest {
 		String region = null;
 
 		// when
-		RegionListResponse response = regionQueryService.searchBySlice(size, cursor, region);
+		RegionListResponse response = regionService.searchBySlice(size, cursor, region);
 
 		// then
 		assertAll(() -> {


### PR DESCRIPTION
## 구현한 것

- 회원 자신이 등록한 동네 2곳중 하나를 선택할때 사용하는 API를 구현하였습니다.

## 실행결과
한 회원은 현재 등록한 동네 2곳이 다음과 같다고 가정합니다. 그리고 현재 선택된 동네는 청운동인것을 알 수 있습니다.

<img width="606" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/71dabd15-1594-4d82-9e00-1a433be7b186">

여기서 동네 주소 선택 API를 사용하여 현재 선택된 동네 주소를 신교동으로 변경해보겠습니다. 포스트맨 입력 상황은 다음과 같이 신교동의 지역 등록번호인 2를 전달합니다.

<img width="1007" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/3c9dac0e-5ef9-48a4-a1c7-cef5a3a6a1c8">

데이터베이스 테이블을 보았을때 이전 청운동으로 선택됬던 회원의 동네 주소가 신교동으로 변경된 것을 확인할 수 있었습니다.

<img width="583" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/1beb9000-450e-4634-a600-0f302afbae93">


