### PR TITLE
[feat] 상품 삭제 서비스 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -6,6 +6,7 @@ import javax.validation.Valid;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -75,5 +76,11 @@ public class ItemController {
 	public ApiResponse<Void> modifyItemStatus(@PathVariable Long itemId, @RequestBody ItemStatusModifyRequest request) {
 		itemService.findById(itemId, request.getStatus());
 		return ApiResponse.ok("상품 상태 변경에 성공하였습니다.", null);
+	}
+
+	@DeleteMapping("/{itemId}")
+	public ApiResponse<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
+		itemService.deleteItem(itemId, principal);
+		return ApiResponse.ok("상품 삭제가 완료되었습니다.", null);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -20,6 +20,7 @@ import codesquard.app.api.item.response.ItemResponse;
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.domain.category.Category;
 import codesquard.app.domain.category.CategoryRepository;
+import codesquard.app.domain.chat.ChatRoomRepository;
 import codesquard.app.domain.image.Image;
 import codesquard.app.domain.image.ImageRepository;
 import codesquard.app.domain.item.Item;
@@ -29,6 +30,7 @@ import codesquard.app.domain.item.ItemStatus;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.pagination.PaginationUtils;
+import codesquard.app.domain.wish.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -43,6 +45,8 @@ public class ItemService {
 	private final ImageService imageService;
 	private final CategoryRepository categoryRepository;
 	private final ItemPaginationRepository itemPaginationRepository;
+	private final WishRepository wishRepository;
+	private final ChatRoomRepository chatRoomRepository;
 
 	@Transactional
 	public void register(ItemRegisterRequest request, List<MultipartFile> itemImage, Long memberId) {
@@ -169,5 +173,21 @@ public class ItemService {
 	private Item findItemBy(Long itemId) {
 		return itemRepository.findById(itemId)
 			.orElseThrow(() -> new RestApiException(ItemErrorCode.ITEM_NOT_FOUND));
+	}
+
+	@Transactional
+	public void deleteItem(Long itemId, Principal writer) {
+		Item item = findItemBy(itemId);
+		item.validateSeller(writer.getMemberId());
+
+		List<Image> images = imageRepository.findAllByItemId(itemId);
+		images.stream()
+			.map(Image::getImageUrl)
+			.forEach(imageService::deleteImage);
+
+		imageRepository.deleteByItemId(itemId);
+		wishRepository.deleteByItemId(itemId);
+		chatRoomRepository.deleteByItemId(itemId);
+		itemRepository.deleteById(itemId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -185,6 +185,10 @@ public class ItemService {
 			.map(Image::getImageUrl)
 			.forEach(imageService::deleteImage);
 
+		deleteAllRelatedItem(itemId);
+	}
+
+	private void deleteAllRelatedItem(Long itemId) {
 		imageRepository.deleteByItemId(itemId);
 		wishRepository.deleteByItemId(itemId);
 		chatRoomRepository.deleteByItemId(itemId);

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -6,4 +6,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 	List<ChatRoom> findAllByItemId(Long itemId);
+
+	int deleteByItemId(Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -28,4 +28,6 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 		@Param("itemId") Long itemId,
 		@Param("imageUrl") String imageUrl,
 		@Param("thumbnail") boolean thumbnail);
+
+	int deleteByItemId(Long itemId);
 }

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -15,6 +15,7 @@ import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -156,5 +157,20 @@ class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("statusCode").value(equalTo(404)))
 			.andExpect(jsonPath("message").value(equalTo("상품을 찾을 수 없습니다.")))
 			.andExpect(jsonPath("data").value(equalTo(null)));
+	}
+
+	@DisplayName("상품을 삭제합니다.")
+	@Test
+	public void deleteItem() throws Exception {
+		// given
+		willDoNothing().given(itemService).deleteItem(
+			ArgumentMatchers.anyLong(),
+			ArgumentMatchers.any(Principal.class));
+
+		// when & then
+		mockMvc.perform(delete("/api/items/1"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("statusCode").value(equalTo(200)))
+			.andExpect(jsonPath("message").value(equalTo("상품 삭제가 완료되었습니다.")));
 	}
 }


### PR DESCRIPTION
## 구현한 것

- 상품 삭제 서비스를 구현하였습니다.
- 상품 삭제시 상품과 관련된 관심(wish), 이미지 데이터가 같이 삭제됩니다.

## 실행결과
현재 다음과 같이 상품 데이터와 상품에 포함되어 있는 이미지 데이터가 저장되어 있습니다.
<img width="846" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/a75881e8-f720-40ec-a37d-3d2ef597f723">

<img width="517" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/c00d84c5-ca60-4f13-9106-aace3eb84d6b">

포스트맨을 이용하여 해당 상품을 삭제합니다. 테이블을 보면 상품 테이블과 이미지 테이블의 데이터가 삭제된 것을 볼 수 있습니다.

<img width="1018" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/eed7cb9b-d4ba-4195-bab0-00639164a5b8">

<img width="689" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/2c29adec-bcbc-4968-a4ad-5f86143d5c30">

<img width="503" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/58727d4a-2291-464a-8e8e-061da9d02ad8">


