### PR TITLE
[feat] @JsonProperty 제거 및 오타 수정

### DIFF
--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.chat.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquard.app.domain.chat.ChatLog;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.AccessLevel;
@@ -14,17 +12,12 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatLogMessageResponse {
 	private int messageIndex;
-	private boolean isMe;
+	private Boolean isMe;
 	private String message;
 
 	public static ChatLogMessageResponse from(int messageIndex, ChatLog chatLog, Principal principal) {
 		boolean isMe = chatLog.isSender(principal.getLoginId());
 		return new ChatLogMessageResponse(messageIndex, isMe, chatLog.getMessage());
-	}
-
-	@JsonProperty("isMe")
-	public boolean isMe() {
-		return isMe;
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -30,7 +30,9 @@ import codesquard.app.api.response.ApiResponse;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/items")
 @RequiredArgsConstructor
@@ -62,6 +64,7 @@ public class ItemController {
 		@AuthPrincipal Principal principal) {
 		itemViewRedisService.addViewCount(itemId);
 		ItemDetailResponse response = itemService.findDetailItemBy(itemId, principal.getMemberId());
+		log.debug("상품 상세 조회 결과 : {}", response);
 		return ApiResponse.ok("상품 상세 조회에 성공하였습니다.", response);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
@@ -3,8 +3,6 @@ package codesquard.app.api.item.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.member.Member;
 import lombok.AccessLevel;
@@ -15,9 +13,8 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ItemDetailResponse {
-
-	@JsonProperty("isSeller")
-	private boolean isSeller;
+	
+	private Boolean isSeller;
 	private List<String> imageUrls;
 	private String seller;
 	private String status;
@@ -64,5 +61,13 @@ public class ItemDetailResponse {
 			.viewCount(item.getViewCount())
 			.price(item.getPrice())
 			.build();
+	}
+
+	@Override
+	public String toString() {
+		return String.format(
+			"ItemDetailResponse{isSeller=%s, imageUrls=%s, seller='%s', status='%s', title='%s', categoryName='%s', createdAt=%s, content='%s', chatCount=%d, wishCount=%d, viewCount=%d, price=%d}",
+			isSeller, imageUrls, seller, status, title, categoryName, createdAt, content, chatCount, wishCount,
+			viewCount, price);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
@@ -59,6 +59,8 @@ public class MemberTownService {
 		Member member = findMemberBy(principal);
 		memberTownRepository.deleteMemberTownByMemberIdAndRegionId(member.getId(), region.getId());
 
+		// TODO: 남은 회원 동네 선택 처리
+
 		return MemberTownRemoveResponse.create(region.getName());
 	}
 

--- a/backend/src/main/java/codesquard/app/api/oauth/response/MemberTownLoginResponse.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/response/MemberTownLoginResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.oauth.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquard.app.domain.membertown.MemberTown;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -15,7 +13,7 @@ public class MemberTownLoginResponse {
 	private Long addressId;
 	private String fullAddressName;
 	private String addressName;
-	private boolean isSelected;
+	private Boolean isSelected;
 
 	public static MemberTownLoginResponse from(MemberTown memberTown) {
 		return new MemberTownLoginResponse(
@@ -23,10 +21,5 @@ public class MemberTownLoginResponse {
 			memberTown.getRegion().getName(),
 			memberTown.getName(),
 			memberTown.isSelected());
-	}
-
-	@JsonProperty("isSelected")
-	public boolean isSelected() {
-		return isSelected;
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -22,9 +22,9 @@ public class WishItemController {
 	private final WishItemService wishItemService;
 
 	@PostMapping("/{itemId}")
-	public ApiResponse<Void> wishStatus(@PathVariable Long itemId, @RequestParam WishStatus status,
+	public ApiResponse<Void> wishStatus(@PathVariable Long itemId, @RequestParam WishStatus wish,
 		@AuthPrincipal Principal principal) {
-		wishItemService.changeWishStatus(itemId, principal.getMemberId(), status);
+		wishItemService.changeWishStatus(itemId, principal.getMemberId(), wish);
 		return ApiResponse.ok("관심상품 변경이 완료되었습니다.", null);
 	}
 

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -6,6 +6,13 @@ spring:
       test: test, secret, s3
     default: local
 
+  jackson:
+    visibility:
+      field: any
+      is-getter: none
+      getter: none
+      setter: none
+      creator: none
 ---
 spring:
   config:


### PR DESCRIPTION
## 구현한 것

- isXX으로 시작하는 필드 멤버에 대해서 Boolean으로 변경하여 필드명 그대로 json 직렬화하도록 변경하였습니다.
- spring.jackson.visibility 속성을 이용하여 field명 그대로 하는 방법도 있었지만 테스트 코드에서 mockMvc로 요청을 하고난 응답에서 isXX 필드명을 생략하게 되어서 설정하지 않았습니다.
- 관심상품 등록, 관심상품 해제 요청에서 쿼리 파라미터명이 wish인데 컨트롤러에서 받는 파라미터명이 status여서 wish로 변경하였습니다.