### PR TITLE
[feat] 회원 동네 삭제시 남은 동네 selected 처리

### DIFF
--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
@@ -12,7 +12,8 @@ public enum MemberTownErrorCode implements ErrorCode {
 	ALREADY_ADDRESS_NAME(HttpStatus.CONFLICT, "이미 존재하는 동네입니다."),
 	UNREGISTERED_ADDRESS_TO_REMOVE(HttpStatus.BAD_REQUEST, "등록되지 않은 동네를 삭제할 수 없습니다."),
 	NOT_SELECT_UNREGISTERED_MEMBER_TOWN(HttpStatus.BAD_REQUEST, "회원이 등록한 동네만 선택할 수 있습니다."),
-	FAIL_REMOVE_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "동네 삭제를 실패하였습니다.");
+	FAIL_REMOVE_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "동네 삭제를 실패하였습니다."),
+	NOT_FOUND_MEMBER_TOWN(HttpStatus.NOT_FOUND, "회원 동네를 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
@@ -25,7 +25,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
 public class MemberTownService {
@@ -35,6 +35,7 @@ public class MemberTownService {
 	private final RegionRepository regionRepository;
 	private final MemberTownValidator memberTownValidator;
 
+	@Transactional
 	public MemberAddRegionResponse addMemberTown(Principal principal, MemberTownAddRequest request) {
 		log.info("회원 동네 추가 서비스 요청 : 회원아이디={}, 추가할 동네 등록번호={}", principal.getLoginId(), request.getAddressId());
 
@@ -49,6 +50,7 @@ public class MemberTownService {
 		return MemberAddRegionResponse.from(town);
 	}
 
+	@Transactional
 	public MemberTownRemoveResponse removeMemberTown(Principal principal, MemberTownRemoveRequest request) {
 		log.info("회원 동네 삭제 서비스 요청 : 회원아이디={}, 삭제할 동네 등록번호={}", principal.getLoginId(), request.getAddressId());
 
@@ -59,7 +61,16 @@ public class MemberTownService {
 		Member member = findMemberBy(principal);
 		memberTownRepository.deleteMemberTownByMemberIdAndRegionId(member.getId(), region.getId());
 
+		changeIsSelectedWithRemainMemberTown(principal);
+
 		return MemberTownRemoveResponse.create(region.getName());
+	}
+
+	private void changeIsSelectedWithRemainMemberTown(Principal principal) {
+		MemberTown remainMemberTown = memberTownRepository.findAllByMemberId(principal.getMemberId()).stream()
+			.findAny()
+			.orElseThrow(() -> new RestApiException(MemberTownErrorCode.NOT_FOUND_MEMBER_TOWN));
+		remainMemberTown.changeIsSelected(true);
 	}
 
 	private Region getAddressIdBy(Long addressId) {

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTown.java
@@ -63,6 +63,10 @@ public class MemberTown {
 		return new MemberTown(region.getShortAddress(), member, region, false);
 	}
 
+	public void changeIsSelected(boolean selected) {
+		this.isSelected = selected;
+	}
+
 	@Override
 	public String toString() {
 		return String.format("%s, %s(id=%d, name=%s, isSelected=%s)", "회원동네", this.getClass().getSimpleName(), id, name,

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
@@ -184,11 +184,16 @@ class MemberTownServiceTest {
 		MemberTownRemoveResponse response = memberTownService.removeMemberTown(Principal.from(saveMember), request);
 
 		// then
-		assertAll(() -> {
-			assertThat(response.getAddress()).isEqualTo("서울 송파구 가락동");
-			assertThat(memberTownRepository.findMemberTownByMemberIdAndName(saveMember.getId(), "가락동")
-				.isEmpty()).isTrue();
-		});
+		assertAll(
+			() -> assertThat(response.getAddress()).isEqualTo("서울 송파구 가락동"),
+			() -> assertThat(memberTownRepository.findMemberTownByMemberIdAndName(saveMember.getId(), "가락동")
+				.isEmpty()).isTrue(),
+			() -> {
+				MemberTown remainMemberTown = memberTownRepository.findMemberTownByMemberIdAndName(saveMember.getId(),
+					"궁정동").orElseThrow();
+				assertThat(remainMemberTown.isSelected()).isTrue();
+			}
+		);
 	}
 
 	@DisplayName("등록되지 않은 주소 이름을 가지고 회원의 동네를 제거할 수 없다")


### PR DESCRIPTION
## 구현한 것

- 회원 동네 삭제시 남은 회원 동네에 대하여 선택처리하도록 수정하였습니다.

## 고민점

- 확장성을 고려하여 회원의 동네가 3개 이상이 되었을때 남은 동네 중에서 어떤 것을 선택 처리해야 하는지에 대한 기준이 필요합니다. 현재는 2개뿐이서 남은 회원에 대한 동네를 조회하여 선택처리하면 되는 상태입니다.
