### PR TITLE
[feat] 관심상품 카테고리 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.wishitem.response.WishCategoryListResponse;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.wish.WishStatus;
@@ -32,5 +33,10 @@ public class WishItemController {
 	public ApiResponse<ItemResponses> findAll(@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor) {
 		return ApiResponse.ok("관심상품 조회에 성공하였습니다.", wishItemService.findAll(categoryId, size, cursor));
+	}
+
+	@GetMapping("/categories")
+	public ApiResponse<WishCategoryListResponse> readWishCategories(@AuthPrincipal Principal principal) {
+		return ApiResponse.ok("관심상품의 카테고리 목록 조회를 완료하였습니다.", wishItemService.readWishCategories(principal));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryItemResponse.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryItemResponse.java
@@ -1,0 +1,21 @@
+package codesquard.app.api.wishitem.response;
+
+import codesquard.app.domain.category.Category;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class WishCategoryItemResponse {
+	private Long categoryId;
+	private String categoryName;
+
+	public static WishCategoryItemResponse from(Category category) {
+		return new WishCategoryItemResponse(category.getId(), category.getName());
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(categoryId=%d, categoryName=%s)", "관심상품 카테고리 항목", this.getClass().getSimpleName(),
+			categoryId, categoryName);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryListResponse.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.wishitem.response;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import codesquard.app.domain.category.Category;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class WishCategoryListResponse {
+	private List<WishCategoryItemResponse> categories;
+
+	public static WishCategoryListResponse of(List<Category> categories) {
+		return new WishCategoryListResponse(categories.stream()
+			.map(WishCategoryItemResponse::from)
+			.collect(Collectors.toUnmodifiableList())
+		);
+	}
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(categories=%s)", "관심상품 카테고리 리스트 응답", this.getClass().getSimpleName(), categories);
+	}
+}

--- a/backend/src/main/java/codesquard/app/domain/wish/Wish.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/Wish.java
@@ -36,9 +36,9 @@ public class Wish {
 	private Item item;
 	private LocalDateTime createdAt;
 
-	public Wish(Member member, Item item, LocalDateTime createdAt) {
+	public Wish(Member member, Item item) {
 		this.member = member;
 		this.item = item;
-		this.createdAt = createdAt;
+		this.createdAt = LocalDateTime.now();
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
@@ -1,5 +1,7 @@
 package codesquard.app.domain.wish;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WishRepository extends JpaRepository<Wish, Long> {
@@ -9,4 +11,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 	int countWishByItemId(Long itemId);
 
 	boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
+
+	List<Wish> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/resources/db/mysql/data.sql
+++ b/backend/src/main/resources/db/mysql/data.sql
@@ -60,6 +60,13 @@ VALUES (0, '롤러블레이드 팝니다', now(), 169000, '청운동', 'ON_SALE'
         'https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
         '롤러 블레이드', 0, 0, 1, 1);
 
+INSERT INTO image (image_url, thumbnail, item_id)
+VALUES ('https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
+        true,
+        1);
+
+
+
 INSERT INTO item(chat_count,
                  content,
                  created_at,
@@ -79,7 +86,36 @@ VALUES (0, '롤러블레이드 팝니다', now(), 169000, '역삼1동', 'ON_SALE
 INSERT INTO image (image_url, thumbnail, item_id)
 VALUES ('https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/roller_blade.jpeg',
         true,
-        1);
+        2);
+
+
+INSERT INTO item(chat_count,
+                 content,
+                 created_at,
+                 price,
+                 region,
+                 status,
+                 thumbnail_url,
+                 title,
+                 view_count,
+                 wish_count,
+                 category_id,
+                 member_id)
+VALUES (0, '의자 팝니다.', now(), 130000, '역삼1동', 'ON_SALE',
+        'https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/char.jpeg',
+        '옛날 의자', 0, 0, 6, 1);
+
+INSERT INTO image (image_url, thumbnail, item_id)
+VALUES ('https://second-hand-team03-a.s3.ap-northeast-2.amazonaws.com/public/sample/char.jpeg',
+        true,
+        3);
+
+INSERT INTO wish(created_at, item_id, member_id)
+VALUES (now(), 1, 2);
+INSERT INTO wish(created_at, item_id, member_id)
+VALUES (now(), 2, 2);
+INSERT INTO wish(created_at, item_id, member_id)
+VALUES (now(), 3, 2);
 
 INSERT INTO chat_room(created_at, item_id, member_id)
 VALUES (now(), 1, 2);

--- a/backend/src/test/java/codesquard/app/ItemTestSupport.java
+++ b/backend/src/test/java/codesquard/app/ItemTestSupport.java
@@ -1,0 +1,28 @@
+package codesquard.app;
+
+import static java.time.LocalDateTime.*;
+
+import codesquard.app.domain.category.Category;
+import codesquard.app.domain.item.Item;
+import codesquard.app.domain.item.ItemStatus;
+import codesquard.app.domain.member.Member;
+
+public class ItemTestSupport {
+
+	public static Item createItem(String title, String content, Long price, ItemStatus status, String region,
+		Member member, Category category) {
+		return Item.builder()
+			.title(title)
+			.content(content)
+			.price(price)
+			.status(status)
+			.region(region)
+			.createdAt(now())
+			.wishCount(0L)
+			.viewCount(0L)
+			.chatCount(0L)
+			.member(member)
+			.category(category)
+			.build();
+	}
+}

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -445,7 +445,7 @@ class ItemServiceTest {
 			new Image("imageUrlValue2", saveItem, false));
 		imageRepository.saveAll(images);
 
-		Wish wish = new Wish(member, item, now());
+		Wish wish = new Wish(member, item);
 		wishRepository.save(wish);
 
 		// when

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemControllerTest.java
@@ -1,0 +1,76 @@
+package codesquard.app.api.wishitem;
+
+import static codesquard.app.CategoryTestSupport.*;
+import static org.hamcrest.Matchers.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import codesquard.app.ControllerTestSupport;
+import codesquard.app.api.wishitem.response.WishCategoryListResponse;
+import codesquard.app.domain.oauth.support.Principal;
+
+@ActiveProfiles("test")
+@WebMvcTest(controllers = WishItemController.class)
+class WishItemControllerTest extends ControllerTestSupport {
+	private MockMvc mockMvc;
+
+	@Autowired
+	private MappingJackson2HttpMessageConverter jackson2HttpMessageConverter;
+
+	@Autowired
+	private WishItemController wishItemController;
+
+	@MockBean
+	private WishItemService wishItemService;
+
+	@BeforeEach
+	public void setup() {
+		mockMvc = MockMvcBuilders.standaloneSetup(wishItemController)
+			.setControllerAdvice(globalExceptionHandler)
+			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
+			.setMessageConverters(jackson2HttpMessageConverter)
+			.alwaysDo(print())
+			.build();
+
+		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
+
+		Principal principal = new Principal(1L, "23Yong@gmail.com", "23Yong", null, null);
+		given(authPrincipalArgumentResolver.resolveArgument(any(), any(), any(), any())).willReturn(principal);
+	}
+
+	@DisplayName("관심 상품들의 카테고리 목록을 요청한다")
+	@Test
+	public void readWishCategories() throws Exception {
+		// given
+		WishCategoryListResponse response = WishCategoryListResponse.of(
+			List.of(findByName("스포츠/레저"), findByName("가구/인테리어")));
+		given(wishItemService.readWishCategories(ArgumentMatchers.any(Principal.class)))
+			.willReturn(response);
+
+		// when & then
+		mockMvc.perform(get("/api/wishes/categories"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("statusCode").value(equalTo(200)))
+			.andExpect(jsonPath("message").value(equalTo("관심상품의 카테고리 목록 조회를 완료하였습니다.")))
+			.andExpect(jsonPath("data.categories[*].categoryName").value(
+				containsInAnyOrder("스포츠/레저", "가구/인테리어")));
+	}
+
+}

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
@@ -1,5 +1,11 @@
 package codesquard.app.api.wishitem;
 
+import static codesquard.app.CategoryTestSupport.*;
+import static codesquard.app.ItemTestSupport.*;
+import static codesquard.app.MemberTestSupport.*;
+import static codesquard.app.MemberTownTestSupport.*;
+import static codesquard.app.RegionTestSupport.*;
+import static codesquard.app.domain.item.ItemStatus.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -7,6 +13,7 @@ import java.util.List;
 
 import javax.persistence.EntityManager;
 
+import org.assertj.core.groups.Tuple;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -17,12 +24,20 @@ import org.springframework.test.context.ActiveProfiles;
 import codesquard.app.api.item.request.ItemRegisterRequest;
 import codesquard.app.api.item.response.ItemResponse;
 import codesquard.app.api.item.response.ItemResponses;
+import codesquard.app.api.wishitem.response.WishCategoryListResponse;
 import codesquard.app.domain.category.Category;
+import codesquard.app.domain.category.CategoryRepository;
+import codesquard.app.domain.image.ImageRepository;
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.item.ItemRepository;
 import codesquard.app.domain.item.ItemStatus;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.member.MemberRepository;
+import codesquard.app.domain.membertown.MemberTownRepository;
+import codesquard.app.domain.oauth.support.Principal;
+import codesquard.app.domain.region.Region;
+import codesquard.app.domain.region.RegionRepository;
+import codesquard.app.domain.wish.Wish;
 import codesquard.app.domain.wish.WishRepository;
 import codesquard.app.domain.wish.WishStatus;
 import codesquard.support.SupportRepository;
@@ -42,13 +57,25 @@ class WishItemServiceTest {
 	@Autowired
 	private ItemRepository itemRepository;
 	@Autowired
+	private CategoryRepository categoryRepository;
+	@Autowired
+	private MemberTownRepository memberTownRepository;
+	@Autowired
+	private RegionRepository regionRepository;
+	@Autowired
+	private ImageRepository imageRepository;
+	@Autowired
 	private EntityManager em;
 
 	@AfterEach
 	void tearDown() {
 		wishRepository.deleteAllInBatch();
+		imageRepository.deleteAllInBatch();
 		itemRepository.deleteAllInBatch();
+		categoryRepository.deleteAllInBatch();
+		memberTownRepository.deleteAllInBatch();
 		memberRepository.deleteAllInBatch();
+		regionRepository.deleteAllInBatch();
 	}
 
 	@Test
@@ -154,5 +181,42 @@ class WishItemServiceTest {
 
 		// then
 		assertThat(responses.getContents()).hasSize(2);
+	}
+
+	@DisplayName("한 회원이 등록한 관심 상품들의 중복되지 않은 카테고리를 조회한다")
+	@Test
+	public void readWishCategories() {
+		// given
+		List<Category> categories = categoryRepository.saveAll(List.of(findByName("스포츠/레저"), findByName("가구/인테리어")));
+		List<Member> members = memberRepository.saveAll(List.of(
+			createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"),
+			createMember("avatarUrlValue", "bruni@gmail.com", "bruni")));
+		List<Region> regions = regionRepository.saveAll(
+			List.of(createRegion("서울 송파구 가락동"), createRegion("서울 종로구 청운동")));
+
+		Member seller = members.get(0);
+		Member buyer = members.get(1);
+		memberTownRepository.saveAll(List.of(
+			createMemberTown(seller, regions.get(0), true),
+			createMemberTown(seller, regions.get(1), false),
+			createMemberTown(buyer, regions.get(0), true),
+			createMemberTown(buyer, regions.get(0), true)));
+		Item item1 = createItem("빈티지 롤러 블레이드", "어린시절 추억의향수를 불러 일으키는 롤러 스케이트입니다.", 200000L, ON_SALE,
+			"가락동", seller, categories.get(0));
+		Item item2 = createItem("빈티지 의자", "의자 팝니다.", 80000L, ON_SALE,
+			"가락동", seller, categories.get(1));
+		itemRepository.saveAll(List.of(item1, item2));
+		wishRepository.saveAll(List.of(new Wish(buyer, item1), new Wish(buyer, item2)));
+		Principal principal = Principal.from(buyer);
+
+		// when
+		WishCategoryListResponse response = wishItemService.readWishCategories(principal);
+
+		// then
+		assertThat(response)
+			.extracting("categories").asList()
+			.extracting("categoryId", "categoryName")
+			.containsExactlyInAnyOrder(Tuple.tuple(1L, "스포츠/레저"), Tuple.tuple(2L, "가구/인테리어"));
+
 	}
 }


### PR DESCRIPTION
## 구현한 것

- 회원이 등록한 관심상품들의 카테고리 목록을 조회하는 API를 구현하였습니다.

## 실행결과
<img width="907" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/312d22ff-09c3-44b2-8f06-dba72e7dc25a">
