### PR TITLE
[feat] 상품 목록 조회 응답에 판매자의 로그인 아이디 sellerId 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -195,6 +195,7 @@ public class ItemService {
 
 	@Transactional
 	public void deleteItem(Long itemId, Principal writer) {
+		log.info("상품 게시글 삭제 서비스 요청 : itemId={}, writer={}", itemId, writer);
 		Item item = findItemByItemIdAndMemberId(itemId, writer.getMemberId());
 		List<Image> images = imageRepository.findAllByItemId(item.getId());
 		images.stream()

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemResponse.java
@@ -17,4 +17,5 @@ public class ItemResponse {
 	private ItemStatus status;
 	private Long chatCount;
 	private Long wishCount;
+	private String sellerId;
 }

--- a/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
@@ -30,7 +30,8 @@ public class ItemPaginationRepository {
 				item.price,
 				item.status,
 				item.wishCount,
-				item.chatCount))
+				item.chatCount,
+				item.member.loginId.as("sellerId")))
 			.from(item)
 			.where(itemRepository.lessThanItemId(itemId),
 				itemRepository.equalCategoryId(categoryId),

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -166,6 +166,7 @@ class ItemServiceTest {
 		assertAll(
 			() -> assertThat(contents.size()).isEqualTo(2),
 			() -> assertThat(contents.get(0).getTitle()).isEqualTo("노트북"),
+			() -> assertThat(contents.get(0).getSellerId()).isEqualTo("pieeeeeee"),
 			() -> assertThat(all.getPaging().isHasNext()).isTrue(),
 			() -> assertThat(all.getPaging().getNextCursor()).isEqualTo(item.getId()));
 	}


### PR DESCRIPTION
## 구현한 것

- 상품 목록 조회시 응답에 판매자의 로그인 아이디를 sellerId 프로퍼티로 응답하도록 추가하였습니다.
- api: /api/items

## 실행결과
<img width="895" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/226bedf8-1724-45fc-a334-0d2b54153b13">


