### PR TITLE
[feat] 상품 상세 조회 응답에 관심여부(isInWishList) 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -102,7 +102,9 @@ public class ItemService {
 			.map(Image::getImageUrl)
 			.collect(Collectors.toUnmodifiableList());
 
-		return ItemDetailResponse.of(item, loginMemberId, imageUrls);
+		boolean isInWishList = wishRepository.existsByMemberIdAndItemId(loginMemberId, itemId);
+
+		return ItemDetailResponse.of(item, loginMemberId, imageUrls, isInWishList);
 	}
 
 	@Transactional

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
@@ -13,7 +13,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class ItemDetailResponse {
-	
+
 	private Boolean isSeller;
 	private List<String> imageUrls;
 	private String seller;
@@ -26,11 +26,12 @@ public class ItemDetailResponse {
 	private Long wishCount;
 	private Long viewCount;
 	private Long price;
+	private Boolean isInWishList;
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private ItemDetailResponse(boolean isSeller, List<String> imageUrls, String seller, String status, String title,
 		String categoryName, LocalDateTime createdAt, String content, Long chatCount, Long wishCount, Long viewCount,
-		Long price) {
+		Long price, Boolean isInWishList) {
 		this.isSeller = isSeller;
 		this.imageUrls = imageUrls;
 		this.seller = seller;
@@ -43,9 +44,10 @@ public class ItemDetailResponse {
 		this.wishCount = wishCount;
 		this.viewCount = viewCount;
 		this.price = price;
+		this.isInWishList = isInWishList;
 	}
 
-	public static ItemDetailResponse of(Item item, Long loginMemberId, List<String> imageUrls) {
+	public static ItemDetailResponse of(Item item, Long loginMemberId, List<String> imageUrls, boolean isInWishList) {
 		Member seller = item.getMember();
 		boolean isSeller = seller.equalId(loginMemberId);
 		return ItemDetailResponse.builder()
@@ -61,6 +63,7 @@ public class ItemDetailResponse {
 			.wishCount(item.getWishCount())
 			.viewCount(item.getViewCount())
 			.price(item.getPrice())
+			.isInWishList(isInWishList)
 			.build();
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
@@ -11,6 +11,6 @@ public interface WishRepository extends JpaRepository<Wish, Long> {
 	void deleteByItemId(Long itemId);
 
 	boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
-
+	
 	List<Wish> findAllByMemberId(Long memberId);
 }

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -80,7 +80,7 @@ class ItemControllerTest extends ControllerTestSupport {
 			.build();
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.of(item, seller.getId(), imageUrls);
+		ItemDetailResponse response = ItemDetailResponse.of(item, seller.getId(), imageUrls, false);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
 		// when & then
 		mockMvc.perform(get("/api/items/1"))
@@ -98,7 +98,8 @@ class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("data.chatCount").value(equalTo(0)))
 			.andExpect(jsonPath("data.wishCount").value(equalTo(0)))
 			.andExpect(jsonPath("data.viewCount").value(equalTo(0)))
-			.andExpect(jsonPath("data.price").value(equalTo(200000)));
+			.andExpect(jsonPath("data.price").value(equalTo(200000)))
+			.andExpect(jsonPath("data.isInWishList").value(equalTo(false)));
 	}
 
 	@DisplayName("구매자가 상품의 상세한 내용을 조회합니다.")
@@ -123,7 +124,7 @@ class ItemControllerTest extends ControllerTestSupport {
 		Long loginMemberId = 9999L;
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.of(item, loginMemberId, imageUrls);
+		ItemDetailResponse response = ItemDetailResponse.of(item, loginMemberId, imageUrls, false);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
 		// when & then
 		mockMvc.perform(get("/api/items/1"))
@@ -141,7 +142,8 @@ class ItemControllerTest extends ControllerTestSupport {
 			.andExpect(jsonPath("data.chatCount").value(equalTo(0)))
 			.andExpect(jsonPath("data.wishCount").value(equalTo(0)))
 			.andExpect(jsonPath("data.viewCount").value(equalTo(0)))
-			.andExpect(jsonPath("data.price").value(equalTo(200000)));
+			.andExpect(jsonPath("data.price").value(equalTo(200000)))
+			.andExpect(jsonPath("data.isInWishList").value(equalTo(false)));
 	}
 
 	@DisplayName("구매자가 상품의 상세한 내용을 조회합니다.")


### PR DESCRIPTION
## 구현한 것

- 상품 상세 조회시 응답에 관심여부(boolean isInWishList) 프로퍼티를 추가하였습니다.
- 해당 프로퍼티를 통하여 클라이언트는 회원이 상품에 대하여 관심을 등록했는지 표시합니다.
- api : /api/items/:itemId
