### PR TITLE
[feat] 판내내역 상품 조회시 컬럼 추가

### DIFF
--- a/backend/src/main/java/codesquard/app/api/category/CategoryQueryService.java
+++ b/backend/src/main/java/codesquard/app/api/category/CategoryQueryService.java
@@ -2,6 +2,7 @@ package codesquard.app.api.category;
 
 import java.util.List;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +18,7 @@ public class CategoryQueryService {
 
 	private final CategoryRepository categoryRepository;
 
+	@Cacheable("categories")
 	public CategoryListResponse findAll() {
 		List<Category> categories = categoryRepository.findAll();
 		return new CategoryListResponse(categories);

--- a/backend/src/main/java/codesquard/app/api/category/CategoryRestController.java
+++ b/backend/src/main/java/codesquard/app/api/category/CategoryRestController.java
@@ -9,7 +9,9 @@ import org.springframework.web.bind.annotation.RestController;
 import codesquard.app.api.category.response.CategoryListResponse;
 import codesquard.app.api.response.ApiResponse;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequestMapping("/api/categories")
 @RequiredArgsConstructor
 @RestController
@@ -20,6 +22,7 @@ public class CategoryRestController {
 	@ResponseStatus(HttpStatus.OK)
 	@GetMapping
 	public ApiResponse<CategoryListResponse> findAll() {
+		log.info("카테고리 목록 조회 요청");
 		return ApiResponse.of(HttpStatus.OK, "카테고리 조회에 성공하였습니다.", categoryQueryService.findAll());
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/category/response/CategoryItemResponse.java
+++ b/backend/src/main/java/codesquard/app/api/category/response/CategoryItemResponse.java
@@ -1,5 +1,7 @@
 package codesquard.app.api.category.response;
 
+import java.io.Serializable;
+
 import codesquard.app.domain.category.Category;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -9,7 +11,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class CategoryItemResponse {
+public class CategoryItemResponse implements Serializable {
 
 	private Long id;
 	private String imageUrl;

--- a/backend/src/main/java/codesquard/app/api/category/response/CategoryListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/category/response/CategoryListResponse.java
@@ -1,5 +1,6 @@
 package codesquard.app.api.category.response;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -10,7 +11,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class CategoryListResponse {
+public class CategoryListResponse implements Serializable {
 
 	private List<CategoryItemResponse> categories;
 

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -4,7 +4,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -90,7 +89,6 @@ public class ItemService {
 		log.info("상품 상태 변경 결과 : item={}", item);
 	}
 
-	@Cacheable(cacheNames = "detailItem")
 	public ItemDetailResponse findDetailItemBy(Long itemId, Long loginMemberId) {
 		log.info("상품 상세 조회 서비스 요청, 상품 등록번호 : {}, 로그인 회원의 등록번호 : {}", itemId, loginMemberId);
 

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
@@ -1,5 +1,6 @@
 package codesquard.app.api.item.response;
 
+import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -12,7 +13,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
-public class ItemDetailResponse {
+public class ItemDetailResponse implements Serializable {
 
 	private Boolean isSeller;
 	private List<String> imageUrls;

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -14,7 +14,9 @@ import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.wish.WishStatus;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RestController
 @RequestMapping("/api/wishes")
 @RequiredArgsConstructor
@@ -37,6 +39,7 @@ public class WishItemController {
 
 	@GetMapping("/categories")
 	public ApiResponse<WishCategoryListResponse> readWishCategories(@AuthPrincipal Principal principal) {
+		log.info("관심 상품들의 카테고리 목록 요청 : {}", principal);
 		return ApiResponse.ok("관심상품의 카테고리 목록 조회를 완료하였습니다.", wishItemService.readWishCategories(principal));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -4,6 +4,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,6 +72,7 @@ public class WishItemService {
 		return PaginationUtils.getItemResponses(itemResponses);
 	}
 
+	@Cacheable("wishCategories")
 	public WishCategoryListResponse readWishCategories(Principal principal) {
 		List<Wish> wishes = wishRepository.findAllByMemberId(principal.getMemberId());
 		List<Category> categories = wishes.stream()

--- a/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryItemResponse.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryItemResponse.java
@@ -1,11 +1,13 @@
 package codesquard.app.api.wishitem.response;
 
+import java.io.Serializable;
+
 import codesquard.app.domain.category.Category;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class WishCategoryItemResponse {
+public class WishCategoryItemResponse implements Serializable {
 	private Long categoryId;
 	private String categoryName;
 

--- a/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/response/WishCategoryListResponse.java
@@ -1,5 +1,6 @@
 package codesquard.app.api.wishitem.response;
 
+import java.io.Serializable;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -8,7 +9,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
-public class WishCategoryListResponse {
+public class WishCategoryListResponse implements Serializable {
 	private List<WishCategoryItemResponse> categories;
 
 	public static WishCategoryListResponse of(List<Category> categories) {

--- a/backend/src/main/java/codesquard/app/config/CacheConfig.java
+++ b/backend/src/main/java/codesquard/app/config/CacheConfig.java
@@ -1,0 +1,9 @@
+package codesquard.app.config;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfig {
+}

--- a/backend/src/main/java/codesquard/app/config/WebConfig.java
+++ b/backend/src/main/java/codesquard/app/config/WebConfig.java
@@ -1,14 +1,17 @@
 package codesquard.app.config;
 
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.format.FormatterRegistry;
+import org.springframework.http.CacheControl;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+import org.springframework.web.servlet.mvc.WebContentInterceptor;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 
@@ -38,6 +41,13 @@ public class WebConfig implements WebMvcConfigurer {
 		registry.addInterceptor(new LogoutInterceptor())
 			.excludePathPatterns("/api/*")
 			.addPathPatterns("/api/auth/logout");
+
+		WebContentInterceptor webCacheContentInterceptor = new WebContentInterceptor();
+		webCacheContentInterceptor.addCacheMapping(
+			CacheControl.maxAge(3600, TimeUnit.SECONDS).noTransform().mustRevalidate(),
+			"/api/categories", "/api/wishes/categories");
+
+		registry.addInterceptor(webCacheContentInterceptor);
 	}
 
 	@Override

--- a/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
@@ -26,10 +26,13 @@ public class SalesPaginationRepository {
 				item.id.as("itemId"),
 				item.thumbnailUrl,
 				item.title,
-				item.region,
+				item.region.as("tradingRegion"),
 				item.createdAt,
 				item.price,
-				item.status))
+				item.status,
+				item.wishCount,
+				item.chatCount,
+				item.member.loginId.as("sellerId")))
 			.from(item)
 			.where(itemRepository.lessThanItemId(cursor),
 				itemRepository.equalsStatus(status))

--- a/backend/src/main/java/codesquard/app/interceptor/CacheInterceptor.java
+++ b/backend/src/main/java/codesquard/app/interceptor/CacheInterceptor.java
@@ -1,0 +1,5 @@
+package codesquard.app.interceptor;
+
+public class CacheInterceptor {
+
+}


### PR DESCRIPTION
## 구현한 것

- 판매내역 상품 조회시 일부 빠진 컬럼들(거래지역, 판매자 로그인 아이디 등)을 추가하였습니다.
- api : /api/sales/history

## 실행결과
<img width="859" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/f90d0e72-c9db-4755-9e55-b79901d23511">
