### PR TITLE
[fix] 채팅 목록 조회시 chatRoomId 등록번호에 따른 메시지만 조회되도록 버그 해결

### DIFF
--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -8,6 +8,8 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.querydsl.core.BooleanBuilder;
+
 import codesquard.app.api.chat.request.ChatLogSendRequest;
 import codesquard.app.api.chat.response.ChatLogItemResponse;
 import codesquard.app.api.chat.response.ChatLogListResponse;
@@ -50,7 +52,11 @@ public class ChatLogService {
 		Item item = findItemBy(chatRoom);
 
 		String chatPartnerName = principal.getChatPartnerName(item, chatRoom);
-		Slice<ChatLog> slice = chatLogPaginationRepository.searchBySlice(cursor, pageable);
+		BooleanBuilder whereBuilder = new BooleanBuilder();
+		whereBuilder.orAllOf(
+			chatLogRepository.greaterThanChatLogId(cursor),
+			chatLogRepository.equalChatRoomId(chatRoomId));
+		Slice<ChatLog> slice = chatLogPaginationRepository.searchBySlice(whereBuilder, pageable);
 
 		List<ChatLog> contents = slice.getContent().stream()
 			.collect(Collectors.toUnmodifiableList());

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.domain.Slice;
 import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -20,22 +20,13 @@ public class ChatLogPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
 
-	public Slice<ChatLog> searchBySlice(Long lastChatLogId, Pageable pageable) {
+	public Slice<ChatLog> searchBySlice(BooleanBuilder whereBuilder, Pageable pageable) {
 		List<ChatLog> chatLogs = queryFactory.selectFrom(chatLog)
-			.where(
-				greaterThanChatLogId(lastChatLogId)
-			)
+			.where(whereBuilder)
 			.orderBy(chatLog.id.asc())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 		return checkLastPage(pageable, chatLogs);
-	}
-
-	private BooleanExpression greaterThanChatLogId(Long chatLogId) {
-		if (chatLogId == null) {
-			return null;
-		}
-		return chatLog.id.gt(chatLogId);
 	}
 
 	private Slice<ChatLog> checkLastPage(Pageable pageable, List<ChatLog> chatLogs) {

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogRepository.java
@@ -1,10 +1,28 @@
 package codesquard.app.domain.chat;
 
+import static codesquard.app.domain.chat.QChatLog.*;
+
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+
 public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
+
+	default BooleanExpression greaterThanChatLogId(Long chatLogId) {
+		if (chatLogId == null) {
+			return null;
+		}
+		return chatLog.id.gt(chatLogId);
+	}
+
+	default BooleanExpression equalChatRoomId(Long chatRoomId) {
+		if (chatRoomId == null) {
+			return null;
+		}
+		return chatLog.chatRoom.id.eq(chatRoomId);
+	}
 
 	Optional<ChatLog> findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 }


### PR DESCRIPTION
## 구현한 것

- 채팅 메시지 목록 조회시 다른 채팅방의 메시지 목록도 조회되는 문제를 해결하였습니다.

## 실행결과
현재 한 상품에 대한 채팅방이 2개 존재하고 각각 15개의 메시지가 존재합니다. 기존에는 30개의 메시지가 전부 조회되었습니다. 하지만 이제는 chatRoomId에 따른 메시지만 조회되도록 해결하였습니다.

<img width="984" alt="image" src="https://github.com/masters2023-project-03-second-hand/second-hand-max-be-a/assets/33227831/a7f97495-d757-401a-a26b-810e02dff33a">
