### PR TITLE
[feat] 상품 상세 조회시 판매자/구매자에 따른 채팅 정보 응답 추가하기

### DIFF
--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -25,7 +25,6 @@ import codesquard.app.api.item.request.ItemRegisterRequest;
 import codesquard.app.api.item.request.ItemStatusModifyRequest;
 import codesquard.app.api.item.response.ItemDetailResponse;
 import codesquard.app.api.item.response.ItemResponses;
-import codesquard.app.api.redis.ItemViewRedisService;
 import codesquard.app.api.response.ApiResponse;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
@@ -39,7 +38,6 @@ import lombok.extern.slf4j.Slf4j;
 public class ItemController {
 
 	private final ItemService itemService;
-	private final ItemViewRedisService itemViewRedisService;
 
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	@ResponseStatus(HttpStatus.CREATED)

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -103,7 +103,12 @@ public class ItemService {
 
 		boolean isInWishList = wishRepository.existsByMemberIdAndItemId(principal.getMemberId(), itemId);
 
-		return ItemDetailResponse.of(item, principal.getMemberId(), imageUrls, isInWishList);
+		if (item.isSeller(principal.getMemberId())) {
+			Long chatRoomId = chatRoomRepository.findByItemIdAndMemberId(itemId, principal.getMemberId())
+				.orElse(null);
+			return ItemDetailResponse.toSeller(item, principal.getMemberId(), imageUrls, isInWishList, chatRoomId);
+		}
+		return ItemDetailResponse.toBuyer(item, principal.getMemberId(), imageUrls, isInWishList);
 	}
 
 	@Transactional

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
@@ -28,11 +28,12 @@ public class ItemDetailResponse implements Serializable {
 	private Long viewCount;
 	private Long price;
 	private Boolean isInWishList;
+	private Long chatRoomId;
 
 	@Builder(access = AccessLevel.PRIVATE)
 	private ItemDetailResponse(boolean isSeller, List<String> imageUrls, String seller, String status, String title,
 		String categoryName, LocalDateTime createdAt, String content, Long chatCount, Long wishCount, Long viewCount,
-		Long price, Boolean isInWishList) {
+		Long price, Boolean isInWishList, Long chatRoomId) {
 		this.isSeller = isSeller;
 		this.imageUrls = imageUrls;
 		this.seller = seller;
@@ -46,9 +47,11 @@ public class ItemDetailResponse implements Serializable {
 		this.viewCount = viewCount;
 		this.price = price;
 		this.isInWishList = isInWishList;
+		this.chatRoomId = chatRoomId;
 	}
 
-	public static ItemDetailResponse of(Item item, Long loginMemberId, List<String> imageUrls, boolean isInWishList) {
+	public static ItemDetailResponse toBuyer(Item item, Long loginMemberId, List<String> imageUrls,
+		boolean isInWishList) {
 		Member seller = item.getMember();
 		boolean isSeller = seller.equalId(loginMemberId);
 		return ItemDetailResponse.builder()
@@ -65,6 +68,28 @@ public class ItemDetailResponse implements Serializable {
 			.viewCount(item.getViewCount())
 			.price(item.getPrice())
 			.isInWishList(isInWishList)
+			.build();
+	}
+
+	public static ItemDetailResponse toSeller(Item item, Long loginMemberId, List<String> imageUrls,
+		boolean isInWishList, Long chatRoomId) {
+		Member seller = item.getMember();
+		boolean isSeller = seller.equalId(loginMemberId);
+		return ItemDetailResponse.builder()
+			.isSeller(isSeller)
+			.imageUrls(imageUrls)
+			.seller(seller.getLoginId())
+			.status(item.getStatus().getStatus())
+			.title(item.getTitle())
+			.categoryName(item.getCategory().getName())
+			.createdAt(item.getCreatedAt())
+			.content(item.getContent())
+			.chatCount(item.getChatCount())
+			.wishCount(item.getWishCount())
+			.viewCount(item.getViewCount())
+			.price(item.getPrice())
+			.isInWishList(isInWishList)
+			.chatRoomId(chatRoomId)
 			.build();
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -1,8 +1,15 @@
 package codesquard.app.domain.chat;
 
+import java.util.Optional;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
 	int deleteByItemId(Long itemId);
+
+	@Query("select chatRoom.id from ChatRoom chatRoom where chatRoom.item.id = :itemId and chatRoom.buyer.id = :memberId")
+	Optional<Long> findByItemIdAndMemberId(@Param("itemId") Long itemId, @Param("memberId") Long memberId);
 }

--- a/backend/src/main/java/codesquard/app/domain/item/Item.java
+++ b/backend/src/main/java/codesquard/app/domain/item/Item.java
@@ -119,7 +119,11 @@ public class Item {
 	public void wishCancel() {
 		this.wishCount--;
 	}
-	
+
+	public boolean isSeller(Long memberId) {
+		return member.getId() == memberId;
+	}
+
 	@Override
 	public String toString() {
 		return String.format("%s, %s(id=%d, title=%s, price=%d, status=%s, region=%s, viewCount=%d)",

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -69,7 +69,7 @@ class ItemControllerTest extends ControllerTestSupport {
 			"가락동", "thumbnailUrl", seller, sport);
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.of(item, seller.getId(), imageUrls, false);
+		ItemDetailResponse response = ItemDetailResponse.toBuyer(item, seller.getId(), imageUrls, false);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
 		// when & then
 		mockMvc.perform(get("/api/items/1"))
@@ -102,7 +102,7 @@ class ItemControllerTest extends ControllerTestSupport {
 		Long loginMemberId = 9999L;
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.of(item, loginMemberId, imageUrls, false);
+		ItemDetailResponse response = ItemDetailResponse.toSeller(item, loginMemberId, imageUrls, false, 1L);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
 		// when & then
 		mockMvc.perform(get("/api/items/1"))

--- a/backend/src/test/java/codesquard/app/api/redis/ItemViewRedisServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/redis/ItemViewRedisServiceTest.java
@@ -93,7 +93,8 @@ class ItemViewRedisServiceTest extends CacheTestSupport {
 		itemViewRedisService.addViewCount(itemId, principal);
 		itemViewRedisService.addViewCount(itemId, principal);
 		// then
-		Long viewCount = Long.valueOf(itemViewRedisService.get(ITEM_ID_PREFIX + itemId));
+		String s = itemViewRedisService.get(ITEM_ID_PREFIX + itemId);
+		Long viewCount = Long.valueOf(s);
 		String itemViewValue = itemViewRedisService.get(principal.createItemViewKey(ITEM_ID_PREFIX + itemId));
 		assertAll(
 			() -> assertThat(viewCount).isEqualTo(1L),


### PR DESCRIPTION
## 구현한 것
- 판매자와 구매자의 응답 구분하기
- 기존 테스트 코드 수정하기

