### PR TITLE
[fix] api 명세서 대로 수정

### DIFF
--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
@@ -1,5 +1,7 @@
 package codesquard.app.api.chat.response;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 import codesquard.app.domain.chat.ChatRoom;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -10,7 +12,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatRoomCreateResponse {
-	
+
+	@JsonProperty(value = "chatRoomId")
 	private Long id;
 
 	public static ChatRoomCreateResponse from(ChatRoom chatRoom) {


### PR DESCRIPTION
## 구현한 것
- `response`의 응답이 `chatRoomId`가 아닌 `id`로 응답해서 `chatRoomId` 로 이름 변경