### PR TITLE
[feat] 채팅 메시지 목록 조회 응답 변경 및 빈 채팅창 조회시 에러 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -12,8 +12,9 @@ plugins {
     id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
+project.base.archivesBaseName('second_hand')
+version = '0.1.0-SNAPSHOT'
 group = 'codesquard'
-version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '11'

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -49,20 +49,20 @@ public class ChatLogRestController {
 	@GetMapping("/chats/{chatRoomId}")
 	public DeferredResult<ApiResponse<ChatLogListResponse>> readMessages(
 		@PathVariable Long chatRoomId,
-		@RequestParam(required = false, defaultValue = "0") Long messageIndex,
+		@RequestParam(required = false, defaultValue = "0") Long messageId,
 		@PageableDefault Pageable pageable,
 		@AuthPrincipal Principal principal) {
-		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, pageable={}, 요청한 아이디={}", chatRoomId, messageIndex, pageable,
+		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, pageable={}, 요청한 아이디={}", chatRoomId, messageId, pageable,
 			principal.getLoginId());
 
 		DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult = new DeferredResult<>(10000L);
-		chatService.putMessageIndex(deferredResult, messageIndex);
+		chatService.putMessageIndex(deferredResult, messageId);
 
 		deferredResult.onCompletion(() -> chatService.removeMessageIndex(deferredResult));
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(
 			ApiResponse.of(HttpStatus.REQUEST_TIMEOUT, "새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
 
-		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageIndex, pageable);
+		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId, pageable);
 
 		if (!response.isEmptyChat()) {
 			deferredResult.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.", response));

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -70,14 +70,13 @@ public class ChatLogService {
 		boolean hasNext = slice.hasNext();
 		Long nextCursor = getNextCursor(messageResponses, hasNext);
 
-		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses, hasNext,
-			nextCursor);
+		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses, nextCursor);
 	}
 
 	private Long getNextCursor(List<ChatLogMessageResponse> contents, boolean hasNext) {
 		Long nextCursor = null;
 		if (hasNext) {
-			nextCursor = contents.get(contents.size() - 1).getMessageIndex();
+			nextCursor = contents.get(contents.size() - 1).getMessageId();
 		}
 		return nextCursor;
 	}

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -150,6 +150,7 @@ public class ChatRoomService {
 
 		List<ChatRoomItemResponse> contents = slice.getContent().stream()
 			.map(getChatRoomItemResponseMapper(newMessageMap, principal))
+			.filter(Objects::nonNull)
 			.sorted(Comparator.comparing(ChatRoomItemResponse::getLastSendTime).reversed())
 			.collect(Collectors.toUnmodifiableList());
 		boolean hasNext = slice.hasNext();

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatLogListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatLogListResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.chat.response;
 
-import static codesquard.app.api.item.response.ItemResponses.*;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -15,22 +13,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ChatLogListResponse {
+
 	private String chatPartnerName;
 	private ChatLogItemResponse item;
 	private List<ChatLogMessageResponse> chat;
-	private Paging paging;
-
-	public ChatLogListResponse(String chatPartnerName, ChatLogItemResponse item, List<ChatLogMessageResponse> chat,
-		boolean hasNext, Long nextCursor) {
-		this.chatPartnerName = chatPartnerName;
-		this.item = item;
-		this.chat = chat;
-		this.paging = Paging.create(nextCursor, hasNext);
-	}
+	private Long nextMessageId;
 
 	public static ChatLogListResponse emptyResponse(String chatPartnerName, Item item) {
-		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), Collections.emptyList(), false,
-			null);
+		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), Collections.emptyList(), null);
 	}
 
 	public boolean isEmptyChat() {

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatLogMessageResponse {
-	private Long messageIndex;
+	private Long messageId;
 	private Boolean isMe;
 	private String message;
 

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.chat.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquard.app.domain.chat.ChatRoom;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,9 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatRoomCreateResponse {
-
-	@JsonProperty(value = "chatRoomId")
-	private Long id;
+	
+	private Long chatRoomId;
 
 	public static ChatRoomCreateResponse from(ChatRoom chatRoom) {
 		return new ChatRoomCreateResponse(chatRoom.getId());

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
@@ -23,7 +23,7 @@ public class ChatLogPaginationRepository {
 	public Slice<ChatLog> searchBySlice(BooleanBuilder whereBuilder, Pageable pageable) {
 		List<ChatLog> chatLogs = queryFactory.selectFrom(chatLog)
 			.where(whereBuilder)
-			.orderBy(chatLog.id.asc())
+			.orderBy(chatLog.id.asc(), chatLog.createdAt.asc())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 		return checkLastPage(pageable, chatLogs);

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
@@ -140,7 +140,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 		ChatLog chatLog = new ChatLog("안녕하세요. 롤러블레이브를 사고 싶습니다. 만원만 깍아주세요.", "23Yong", "carlynne", chatRoom, 1);
 		ChatLogMessageResponse messageResponse = ChatLogMessageResponse.from(chatLog, Principal.from(buyer));
 		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(messageResponse),
-			false, null);
+			null);
 		given(chatLogService.readMessages(anyLong(), any(Principal.class), anyLong(), any(Pageable.class)))
 			.willReturn(response);
 		int chatRoomId = 1;
@@ -168,7 +168,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 	public void readMessagesWithTimeout() throws Exception {
 		// given
 		ChatLogItemResponse itemResponse = null;
-		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(), false, null);
+		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(), null);
 		given(chatLogService.readMessages(
 			anyLong(),
 			any(Principal.class),

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.HashMap;
@@ -27,7 +26,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import codesquard.app.ControllerTestSupport;
@@ -78,7 +76,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 	public void createChatRoom() throws Exception {
 		// given
 		Map<String, Object> responseBody = new HashMap<>();
-		responseBody.put("id", 1L);
+		responseBody.put("chatRoomId", 1L);
 
 		ChatRoomCreateResponse response = objectMapper.readValue(objectMapper.writeValueAsString(responseBody),
 			ChatRoomCreateResponse.class);
@@ -93,7 +91,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("statusCode").value(equalTo(201)))
 			.andExpect(jsonPath("message").value(equalTo("채팅방 생성을 완료하였습니다.")))
-			.andExpect(jsonPath("data.id").value(equalTo(1)));
+			.andExpect(jsonPath("data.chatRoomId").value(equalTo(1)));
 	}
 
 	@DisplayName("회원은 채팅방 목록을 요청한다")
@@ -120,11 +118,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 			.willReturn(response);
 
 		// when & then
-		MvcResult asyncListener = mockMvc.perform(get("/api/chats"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(asyncListener))
+		mockMvc.perform(get("/api/chats"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("statusCode").value(equalTo(200)))
 			.andExpect(jsonPath("message").value(equalTo("채팅방 목록 조회를 완료하였습니다.")))

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
@@ -117,7 +117,7 @@ class ChatRoomServiceTest {
 		// then
 		assertAll(() -> {
 			assertThat(response)
-				.extracting("id")
+				.extracting("chatRoomId")
 				.isNotNull();
 		});
 	}


### PR DESCRIPTION
## 구현한 것

- 채팅방만 생성되어 있고 채팅 메시지가 없는 상태에서 채팅방 목록 조회시 404가 응답되었습니다.
- 원인은 채팅방이 있는 상태에서 무조건 채팅 메시지가 있다고 가정하고 mapper를 진행하다가 채팅 메시지가 없는 경우 404 예외가 발생하도록 구현하였습니다.
- mapper를 진행하다가 한 채팅방에 채팅 메시지가 없는 경우에는 null로 반환하고 결과 배열에 포함되지 않도록 수정하였습니다.
- 채팅 메시지 목록 조회시 messageId로 응답하도록 수정하였습니다.
- 채팅 메시지 목록 조회시 nextMessageId가 응답되도록 수정하였습니다.
- ChatRoomCreateResponse 클래스의 id -> chatRoomId로 필드멤버명을 변경하였습니다. "@JsonProperty"를 제거하였습니다.