### PR TITLE
[fix] 6주차 리뷰 사항 반영

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -12,8 +12,9 @@ plugins {
     id 'com.ewerk.gradle.plugins.querydsl' version '1.0.10'
 }
 
+project.base.archivesBaseName('second_hand')
+version = '0.1.0-SNAPSHOT'
 group = 'codesquard'
-version = '0.0.1-SNAPSHOT'
 
 java {
     sourceCompatibility = '11'

--- a/backend/src/main/java/codesquard/app/api/category/CategoryRestController.java
+++ b/backend/src/main/java/codesquard/app/api/category/CategoryRestController.java
@@ -8,6 +8,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.category.response.CategoryListResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.CategorySuccessCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,6 +24,6 @@ public class CategoryRestController {
 	@GetMapping
 	public ApiResponse<CategoryListResponse> findAll() {
 		log.info("카테고리 목록 조회 요청");
-		return ApiResponse.of(HttpStatus.OK, "카테고리 조회에 성공하였습니다.", categoryQueryService.findAll());
+		return ApiResponse.success(CategorySuccessCode.OK_CATEGORIES, categoryQueryService.findAll());
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -3,7 +3,6 @@ package codesquard.app.api.chat;
 import java.util.Collections;
 
 import org.springframework.http.HttpStatus;
-import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -18,13 +17,13 @@ import codesquard.app.api.chat.request.ChatLogSendRequest;
 import codesquard.app.api.chat.response.ChatLogListResponse;
 import codesquard.app.api.chat.response.ChatLogSendResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.ChatLogSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-@Validated
 @RequiredArgsConstructor
 @RequestMapping("/api")
 @RestController
@@ -41,7 +40,7 @@ public class ChatLogRestController {
 		@AuthPrincipal Principal sender) {
 		ChatLogSendResponse response = chatLogService.sendMessage(request, chatRoomId, sender);
 		chatService.onMessage(chatRoomId);
-		return ApiResponse.created("메시지 전송이 완료되었습니다.", response);
+		return ApiResponse.success(ChatLogSuccessCode.CREATED_CHAT_LOG, response);
 	}
 
 	@GetMapping("/chats/{chatRoomId}")
@@ -56,12 +55,12 @@ public class ChatLogRestController {
 
 		deferredResult.onCompletion(() -> chatService.removeMessageIndex(deferredResult));
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(
-			ApiResponse.ok("새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
+			ApiResponse.success(ChatLogSuccessCode.OK_NOT_NEW_CHAT_LOG, Collections.emptyList())));
 
 		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId);
 
 		if (!response.isEmptyChat()) {
-			deferredResult.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.", response));
+			deferredResult.setResult(ApiResponse.success(ChatLogSuccessCode.OK_CHAT_LOGS, response));
 		}
 		return deferredResult;
 	}

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -2,8 +2,6 @@ package codesquard.app.api.chat;
 
 import java.util.Collections;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.web.PageableDefault;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -50,10 +48,8 @@ public class ChatLogRestController {
 	public DeferredResult<ApiResponse<ChatLogListResponse>> readMessages(
 		@PathVariable Long chatRoomId,
 		@RequestParam(required = false, defaultValue = "0") Long messageId,
-		@PageableDefault Pageable pageable,
 		@AuthPrincipal Principal principal) {
-		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, pageable={}, 요청한 아이디={}", chatRoomId, messageId, pageable,
-			principal.getLoginId());
+		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, 요청한 아이디={}", chatRoomId, messageId, principal.getLoginId());
 
 		DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult = new DeferredResult<>(10000L);
 		chatService.putMessageIndex(deferredResult, messageId);
@@ -62,7 +58,7 @@ public class ChatLogRestController {
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(
 			ApiResponse.ok("새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
 
-		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId, pageable);
+		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId);
 
 		if (!response.isEmptyChat()) {
 			deferredResult.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.", response));

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -49,20 +49,20 @@ public class ChatLogRestController {
 	@GetMapping("/chats/{chatRoomId}")
 	public DeferredResult<ApiResponse<ChatLogListResponse>> readMessages(
 		@PathVariable Long chatRoomId,
-		@RequestParam(required = false, defaultValue = "0") Long messageIndex,
+		@RequestParam(required = false, defaultValue = "0") Long messageId,
 		@PageableDefault Pageable pageable,
 		@AuthPrincipal Principal principal) {
-		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, pageable={}, 요청한 아이디={}", chatRoomId, messageIndex, pageable,
+		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, pageable={}, 요청한 아이디={}", chatRoomId, messageId, pageable,
 			principal.getLoginId());
 
 		DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult = new DeferredResult<>(10000L);
-		chatService.putMessageIndex(deferredResult, messageIndex);
+		chatService.putMessageIndex(deferredResult, messageId);
 
 		deferredResult.onCompletion(() -> chatService.removeMessageIndex(deferredResult));
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(
 			ApiResponse.of(HttpStatus.REQUEST_TIMEOUT, "새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
 
-		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageIndex, pageable);
+		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId, pageable);
 
 		if (!response.isEmptyChat()) {
 			deferredResult.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.", response));

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -60,7 +60,7 @@ public class ChatLogRestController {
 
 		deferredResult.onCompletion(() -> chatService.removeMessageIndex(deferredResult));
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(
-			ApiResponse.of(HttpStatus.REQUEST_TIMEOUT, "새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
+			ApiResponse.ok("새로운 채팅 메시지가 존재하지 않습니다.", Collections.emptyList())));
 
 		ChatLogListResponse response = chatLogService.readMessages(chatRoomId, principal, messageId, pageable);
 

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogRestController.java
@@ -40,7 +40,7 @@ public class ChatLogRestController {
 		@RequestBody ChatLogSendRequest request,
 		@AuthPrincipal Principal sender) {
 		ChatLogSendResponse response = chatLogService.sendMessage(request, chatRoomId, sender);
-		chatService.onMessage(chatRoomId, sender);
+		chatService.onMessage(chatRoomId);
 		return ApiResponse.created("메시지 전송이 완료되었습니다.", response);
 	}
 
@@ -52,7 +52,7 @@ public class ChatLogRestController {
 		log.info("메시지 읽기 요청 : chatRoomId={}, cursor={}, 요청한 아이디={}", chatRoomId, messageId, principal.getLoginId());
 
 		DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult = new DeferredResult<>(10000L);
-		chatService.putMessageIndex(deferredResult, messageId);
+		chatService.putMessageIndex(deferredResult, messageId, principal);
 
 		deferredResult.onCompletion(() -> chatService.removeMessageIndex(deferredResult));
 		deferredResult.onTimeout(() -> deferredResult.setErrorResult(

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -14,7 +14,6 @@ import codesquard.app.api.chat.response.ChatLogListResponse;
 import codesquard.app.api.chat.response.ChatLogMessageResponse;
 import codesquard.app.api.chat.response.ChatLogSendResponse;
 import codesquard.app.api.errors.errorcode.ErrorCode;
-import codesquard.app.api.errors.exception.ForBiddenException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.domain.chat.ChatLog;
 import codesquard.app.domain.chat.ChatLogPaginationRepository;
@@ -49,10 +48,6 @@ public class ChatLogService {
 	public ChatLogListResponse readMessages(Long chatRoomId, Principal principal, Long cursor) {
 		ChatRoom chatRoom = findChatRoomBy(chatRoomId);
 		Item item = findItemBy(chatRoom);
-
-		if (!principal.isSeller(chatRoom.getSeller()) && !principal.isBuyer(chatRoom.getBuyer())) {
-			throw new ForBiddenException(ErrorCode.FORBIDDEN_CHAT_LOG);
-		}
 
 		String chatPartnerName = principal.getChatPartnerName(item, chatRoom);
 		BooleanBuilder whereBuilder = new BooleanBuilder();

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -3,7 +3,6 @@ package codesquard.app.api.chat;
 import java.util.List;
 import java.util.stream.Collectors;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -47,7 +46,7 @@ public class ChatLogService {
 	}
 
 	@Transactional
-	public ChatLogListResponse readMessages(Long chatRoomId, Principal principal, Long cursor, Pageable pageable) {
+	public ChatLogListResponse readMessages(Long chatRoomId, Principal principal, Long cursor) {
 		ChatRoom chatRoom = findChatRoomBy(chatRoomId);
 		Item item = findItemBy(chatRoom);
 
@@ -69,7 +68,10 @@ public class ChatLogService {
 			.map(c -> ChatLogMessageResponse.from(c, principal))
 			.collect(Collectors.toUnmodifiableList());
 
-		Long nextMessageId = chatLogs.get(chatLogs.size() - 1).getId();
+		Long nextMessageId = null;
+		if (!chatLogs.isEmpty()) {
+			nextMessageId = chatLogs.get(chatLogs.size() - 1).getId();
+		}
 		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses,
 			nextMessageId);
 	}

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -44,6 +44,11 @@ public class ChatLogService {
 		return ChatLogSendResponse.from(chatLogRepository.save(chatLog));
 	}
 
+	private ChatRoom findChatRoomBy(Long chatRoomId) {
+		return chatRoomRepository.findById(chatRoomId)
+			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_CHATROOM));
+	}
+
 	@Transactional
 	public ChatLogListResponse readMessages(Long chatRoomId, Principal principal, Long cursor) {
 		ChatRoom chatRoom = findChatRoomBy(chatRoomId);
@@ -69,11 +74,6 @@ public class ChatLogService {
 		}
 		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses,
 			nextMessageId);
-	}
-
-	private ChatRoom findChatRoomBy(Long chatRoomId) {
-		return chatRoomRepository.findById(chatRoomId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_CHATROOM));
 	}
 
 	private Item findItemBy(ChatRoom chatRoom) {

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -16,6 +16,7 @@ import codesquard.app.api.chat.response.ChatLogListResponse;
 import codesquard.app.api.chat.response.ChatLogMessageResponse;
 import codesquard.app.api.chat.response.ChatLogSendResponse;
 import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.exception.ForBiddenException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.domain.chat.ChatLog;
 import codesquard.app.domain.chat.ChatLogPaginationRepository;
@@ -50,6 +51,10 @@ public class ChatLogService {
 	public ChatLogListResponse readMessages(Long chatRoomId, Principal principal, Long cursor, Pageable pageable) {
 		ChatRoom chatRoom = findChatRoomBy(chatRoomId);
 		Item item = findItemBy(chatRoom);
+
+		if (!principal.isSeller(chatRoom.getSeller()) && !principal.isBuyer(chatRoom.getBuyer())) {
+			throw new ForBiddenException(ErrorCode.FORBIDDEN_CHAT_LOG);
+		}
 
 		String chatPartnerName = principal.getChatPartnerName(item, chatRoom);
 		BooleanBuilder whereBuilder = new BooleanBuilder();

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -58,8 +58,8 @@ public class ChatLogService {
 		String chatPartnerName = principal.getChatPartnerName(item, chatRoom);
 		BooleanBuilder whereBuilder = new BooleanBuilder();
 		whereBuilder.orAllOf(
-			chatLogRepository.greaterThanChatLogId(cursor),
-			chatLogRepository.equalChatRoomId(chatRoomId));
+			chatLogPaginationRepository.greaterThanChatLogId(cursor),
+			chatLogPaginationRepository.equalChatRoomId(chatRoomId));
 		List<ChatLog> chatLogs = chatLogPaginationRepository.searchBy(whereBuilder);
 
 		// 메시지 읽는다.

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -70,14 +70,13 @@ public class ChatLogService {
 		boolean hasNext = slice.hasNext();
 		Long nextCursor = getNextCursor(messageResponses, hasNext);
 
-		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses, hasNext,
-			nextCursor);
+		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), messageResponses, nextCursor);
 	}
 
 	private Long getNextCursor(List<ChatLogMessageResponse> contents, boolean hasNext) {
 		Long nextCursor = null;
 		if (hasNext) {
-			nextCursor = contents.get(contents.size() - 1).getMessageIndex();
+			nextCursor = contents.get(contents.size() - 1).getMessageId();
 		}
 		return nextCursor;
 	}

--- a/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatLogService.java
@@ -13,7 +13,8 @@ import codesquard.app.api.chat.response.ChatLogItemResponse;
 import codesquard.app.api.chat.response.ChatLogListResponse;
 import codesquard.app.api.chat.response.ChatLogMessageResponse;
 import codesquard.app.api.chat.response.ChatLogSendResponse;
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ChatRoomErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.domain.chat.ChatLog;
 import codesquard.app.domain.chat.ChatLogPaginationRepository;
@@ -46,7 +47,7 @@ public class ChatLogService {
 
 	private ChatRoom findChatRoomBy(Long chatRoomId) {
 		return chatRoomRepository.findById(chatRoomId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_CHATROOM));
+			.orElseThrow(() -> new NotFoundResourceException(ChatRoomErrorCode.NOT_FOUND_CHATROOM));
 	}
 
 	@Transactional
@@ -78,6 +79,6 @@ public class ChatLogService {
 
 	private Item findItemBy(ChatRoom chatRoom) {
 		return itemRepository.findById(chatRoom.getItem().getId())
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomRestController.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomRestController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 import codesquard.app.api.chat.response.ChatRoomCreateResponse;
 import codesquard.app.api.chat.response.ChatRoomListResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.ChatRoomSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
@@ -30,7 +31,7 @@ public class ChatRoomRestController {
 		@PathVariable Long itemId,
 		@AuthPrincipal Principal buyer) {
 		ChatRoomCreateResponse response = chatRoomService.createChatRoom(itemId, buyer);
-		return ApiResponse.created("채팅방 생성을 완료하였습니다.", response);
+		return ApiResponse.success(ChatRoomSuccessCode.CREATED_CHAT_ROOM, response);
 	}
 
 	@GetMapping("/chats")
@@ -38,7 +39,7 @@ public class ChatRoomRestController {
 		@PageableDefault Pageable pageable,
 		@AuthPrincipal Principal principal) {
 		ChatRoomListResponse response = chatRoomService.readAllChatRoom(principal, pageable);
-		return ApiResponse.ok("채팅방 목록 조회를 완료하였습니다.", response);
+		return ApiResponse.success(ChatRoomSuccessCode.OK_CHAT_ROOMS, response);
 	}
 
 	@GetMapping("/items/{itemId}/chats")
@@ -47,6 +48,6 @@ public class ChatRoomRestController {
 		@PageableDefault Pageable pageable,
 		@AuthPrincipal Principal principal) {
 		ChatRoomListResponse response = chatRoomService.readAllChatRoomByItem(itemId, principal, pageable);
-		return ApiResponse.ok("상품에 따른 채팅방 목록 조회를 완료하였습니다.", response);
+		return ApiResponse.success(ChatRoomSuccessCode.OK_CHAT_ROOMS_BY_ITEMS, response);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -18,15 +18,14 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import codesquard.app.api.chat.response.ChatRoomCreateResponse;
 import codesquard.app.api.chat.response.ChatRoomItemResponse;
 import codesquard.app.api.chat.response.ChatRoomListResponse;
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
-import codesquard.app.domain.chat.ChatLog;
 import codesquard.app.domain.chat.ChatLogCountRepository;
 import codesquard.app.domain.chat.ChatLogRepository;
 import codesquard.app.domain.chat.ChatRoom;
 import codesquard.app.domain.chat.ChatRoomPaginationRepository;
 import codesquard.app.domain.chat.ChatRoomRepository;
-import codesquard.app.domain.chat.QChatRoom;
 import codesquard.app.domain.item.Item;
 import codesquard.app.domain.item.ItemRepository;
 import codesquard.app.domain.member.Member;
@@ -66,12 +65,12 @@ public class ChatRoomService {
 
 	private Item findItemBy(Long itemId) {
 		return itemRepository.findById(itemId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 	}
 
 	private Member findMemberBy(Long memberId) {
 		return memberRepository.findById(memberId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
 
 	public ChatRoomListResponse readAllChatRoom(Principal principal, Pageable pageable) {
@@ -84,12 +83,12 @@ public class ChatRoomService {
 			.collect(Collectors.toUnmodifiableList());
 		log.info("회원이 판매하는 상품 아이디 : {}", itemIds);
 
-		// 1. 내가 팔고 있는 상품들의 등록번호 조회 조건
-		BooleanExpression chatRoomOfSellingItemsCondition = QChatRoom.chatRoom.item.id.in(itemIds);
-		// 2. 내가 사려고 하는 상품에 대한 채팅방 목록 조회 조건
-		BooleanExpression chatRoomOfBuyingItemsCondition = QChatRoom.chatRoom.buyer.id.eq(principal.getMemberId());
+		BooleanExpression inItemIdsOfChatRoom = chatRoomPaginationRepository.inItemIdsOfChatRoom(itemIds);
+		BooleanExpression equalBuyerIdOfChatRoom =
+			chatRoomPaginationRepository.equalBuyerIdOfChatRoom(principal.getMemberId());
+
 		BooleanBuilder whereBuilder = new BooleanBuilder();
-		whereBuilder.andAnyOf(chatRoomOfSellingItemsCondition, chatRoomOfBuyingItemsCondition);
+		whereBuilder.andAnyOf(inItemIdsOfChatRoom, equalBuyerIdOfChatRoom);
 
 		Slice<ChatRoom> slice = chatRoomPaginationRepository.searchBySlice(whereBuilder, pageable);
 		log.info("채팅방 페이징 조회 결과 개수 : {}", slice.getSize());
@@ -108,19 +107,14 @@ public class ChatRoomService {
 	private Function<ChatRoom, ChatRoomItemResponse> getChatRoomItemResponseMapper(Map<Long, Long> newMessageMap,
 		Principal principal) {
 
-		return chatRoom -> {
-			ChatLog chatLog = chatLogRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId())
-				.orElse(null);
-			if (chatLog == null) {
-				return null;
-			}
-			return ChatRoomItemResponse.of(
+		return chatRoom -> chatLogRepository.findFirstByChatRoomIdOrderByCreatedAtDesc(chatRoom.getId())
+			.map(chatlog -> ChatRoomItemResponse.of(
 				chatRoom,
 				chatRoom.getItem(),
 				getChatRoomPartner(principal, chatRoom),
-				chatLog,
-				newMessageMap.getOrDefault(chatRoom.getId(), 0L));
-		};
+				chatlog,
+				newMessageMap.getOrDefault(chatRoom.getId(), 0L)))
+			.orElse(null);
 	}
 
 	private Member getChatRoomPartner(Principal principal, ChatRoom chatRoom) {
@@ -145,7 +139,7 @@ public class ChatRoomService {
 
 		Item item = findItemBy(itemId);
 		BooleanBuilder whereBuilder = new BooleanBuilder();
-		whereBuilder.andAnyOf(chatRoomRepository.equalItemId(item.getId()));
+		whereBuilder.andAnyOf(chatRoomPaginationRepository.equalItemId(item.getId()));
 
 		Slice<ChatRoom> slice = chatRoomPaginationRepository.searchBySlice(whereBuilder, pageable);
 

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -53,6 +53,7 @@ public class ChatRoomService {
 		log.info("채팅방 생성 서비스 요청 : itemId={}, sender={}", itemId, sender);
 
 		Item item = findItemBy(itemId);
+		item.increaseChatCount();
 		Member senderMember = findMemberBy(sender.getMemberId());
 
 		ChatRoom chatRoom = new ChatRoom(senderMember, item);

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -150,6 +150,7 @@ public class ChatRoomService {
 
 		List<ChatRoomItemResponse> contents = slice.getContent().stream()
 			.map(getChatRoomItemResponseMapper(newMessageMap, principal))
+			.filter(Objects::nonNull)
 			.sorted(Comparator.comparing(ChatRoomItemResponse::getLastSendTime).reversed())
 			.collect(Collectors.toUnmodifiableList());
 		boolean hasNext = slice.hasNext();

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -144,7 +144,7 @@ public class ChatRoomService {
 
 		Item item = findItemBy(itemId);
 		BooleanBuilder whereBuilder = new BooleanBuilder();
-		whereBuilder.andAnyOf(QChatRoom.chatRoom.item.eq(item));
+		whereBuilder.andAnyOf(chatRoomRepository.equalItemId(item.getId()));
 
 		Slice<ChatRoom> slice = chatRoomPaginationRepository.searchBySlice(whereBuilder, pageable);
 

--- a/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatRoomService.java
@@ -91,7 +91,7 @@ public class ChatRoomService {
 		whereBuilder.andAnyOf(inItemIdsOfChatRoom, equalBuyerIdOfChatRoom);
 
 		Slice<ChatRoom> slice = chatRoomPaginationRepository.searchBySlice(whereBuilder, pageable);
-		log.info("채팅방 페이징 조회 결과 개수 : {}", slice.getSize());
+		log.info("채팅방 페이징 조회 결과 : {}", slice.getContent());
 
 		List<ChatRoomItemResponse> contents = slice.getContent().stream()
 			.map(getChatRoomItemResponseMapper(newMessageMap, principal))
@@ -142,6 +142,7 @@ public class ChatRoomService {
 		whereBuilder.andAnyOf(chatRoomPaginationRepository.equalItemId(item.getId()));
 
 		Slice<ChatRoom> slice = chatRoomPaginationRepository.searchBySlice(whereBuilder, pageable);
+		log.info("채팅방 목록 조회 결과 : {}", slice.getContent());
 
 		List<ChatRoomItemResponse> contents = slice.getContent().stream()
 			.map(getChatRoomItemResponseMapper(newMessageMap, principal))

--- a/backend/src/main/java/codesquard/app/api/chat/ChatService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatService.java
@@ -3,7 +3,6 @@ package codesquard.app.api.chat;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.web.context.request.async.DeferredResult;
 
@@ -16,8 +15,6 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class ChatService {
 
-	private static final int DEFAULT_READ_MESSAGE_SIZE = 10;
-
 	private final Map<DeferredResult<ApiResponse<ChatLogListResponse>>, Long> chatRequests =
 		new ConcurrentHashMap<>();
 
@@ -28,7 +25,7 @@ public class ChatService {
 			DeferredResult<ApiResponse<ChatLogListResponse>> key = entry.getKey();
 			Long cursor = entry.getValue();
 			key.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.",
-				chatLogService.readMessages(chatRoomId, sender, cursor, Pageable.ofSize(DEFAULT_READ_MESSAGE_SIZE))));
+				chatLogService.readMessages(chatRoomId, sender, cursor)));
 		}
 	}
 

--- a/backend/src/main/java/codesquard/app/api/chat/ChatService.java
+++ b/backend/src/main/java/codesquard/app/api/chat/ChatService.java
@@ -1,5 +1,6 @@
 package codesquard.app.api.chat;
 
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -15,22 +16,27 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class ChatService {
 
-	private final Map<DeferredResult<ApiResponse<ChatLogListResponse>>, Long> chatRequests =
+	private final Map<DeferredResult<ApiResponse<ChatLogListResponse>>, Map<String, Object>> chatRequests =
 		new ConcurrentHashMap<>();
 
 	private final ChatLogService chatLogService;
 
-	public void onMessage(Long chatRoomId, Principal sender) {
-		for (Map.Entry<DeferredResult<ApiResponse<ChatLogListResponse>>, Long> entry : this.chatRequests.entrySet()) {
+	public void onMessage(Long chatRoomId) {
+		for (Map.Entry<DeferredResult<ApiResponse<ChatLogListResponse>>, Map<String, Object>> entry : this.chatRequests.entrySet()) {
 			DeferredResult<ApiResponse<ChatLogListResponse>> key = entry.getKey();
-			Long cursor = entry.getValue();
+			Long cursor = (Long)entry.getValue().get("messageId");
+			Principal requester = (Principal)entry.getValue().get("requester");
 			key.setResult(ApiResponse.ok("채팅 메시지 목록 조회가 완료되었습니다.",
-				chatLogService.readMessages(chatRoomId, sender, cursor)));
+				chatLogService.readMessages(chatRoomId, requester, cursor)));
 		}
 	}
 
-	public void putMessageIndex(DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult, Long messageIndex) {
-		chatRequests.put(deferredResult, messageIndex);
+	public void putMessageIndex(DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult, Long messageId,
+		Principal requester) {
+		Map<String, Object> map = new HashMap<>();
+		map.put("messageId", messageId);
+		map.put("requester", requester);
+		chatRequests.put(deferredResult, map);
 	}
 
 	public void removeMessageIndex(DeferredResult<ApiResponse<ChatLogListResponse>> deferredResult) {

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatLogListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatLogListResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.chat.response;
 
-import static codesquard.app.api.item.response.ItemResponses.*;
-
 import java.util.Collections;
 import java.util.List;
 
@@ -15,22 +13,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor
 public class ChatLogListResponse {
+
 	private String chatPartnerName;
 	private ChatLogItemResponse item;
 	private List<ChatLogMessageResponse> chat;
-	private Paging paging;
-
-	public ChatLogListResponse(String chatPartnerName, ChatLogItemResponse item, List<ChatLogMessageResponse> chat,
-		boolean hasNext, Long nextCursor) {
-		this.chatPartnerName = chatPartnerName;
-		this.item = item;
-		this.chat = chat;
-		this.paging = Paging.create(nextCursor, hasNext);
-	}
+	private Long nextMessageId;
 
 	public static ChatLogListResponse emptyResponse(String chatPartnerName, Item item) {
-		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), Collections.emptyList(), false,
-			null);
+		return new ChatLogListResponse(chatPartnerName, ChatLogItemResponse.from(item), Collections.emptyList(), null);
 	}
 
 	public boolean isEmptyChat() {

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatLogMessageResponse.java
@@ -11,7 +11,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatLogMessageResponse {
-	private Long messageIndex;
+	private Long messageId;
 	private Boolean isMe;
 	private String message;
 

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomCreateResponse.java
@@ -1,7 +1,5 @@
 package codesquard.app.api.chat.response;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
-
 import codesquard.app.domain.chat.ChatRoom;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -12,9 +10,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class ChatRoomCreateResponse {
-
-	@JsonProperty(value = "chatRoomId")
-	private Long id;
+	
+	private Long chatRoomId;
 
 	public static ChatRoomCreateResponse from(ChatRoom chatRoom) {
 		return new ChatRoomCreateResponse(chatRoom.getId());

--- a/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomListResponse.java
+++ b/backend/src/main/java/codesquard/app/api/chat/response/ChatRoomListResponse.java
@@ -17,8 +17,4 @@ public class ChatRoomListResponse {
 		this.contents = contents;
 		this.paging = ItemResponses.Paging.create(nextCursor, hasNext);
 	}
-
-	public boolean isEmptyChatRooms() {
-		return contents.isEmpty();
-	}
 }

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/CategoryErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/CategoryErrorCode.java
@@ -1,0 +1,24 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+	NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "카테고리 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ChatLogErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ChatLogErrorCode.java
@@ -1,0 +1,26 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatLogErrorCode implements ErrorCode {
+
+	NOT_FOUND_CHAT_LOG(HttpStatus.NOT_FOUND, "채팅이 존재하지 않습니다."),
+	FORBIDDEN_CHAT_LOG(HttpStatus.FORBIDDEN, "채팅에 대한 권한이 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "채팅 메시지 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ChatRoomErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ChatRoomErrorCode.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomErrorCode implements ErrorCode {
+
+	NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "채팅방 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ErrorCode.java
@@ -61,6 +61,7 @@ public enum ErrorCode {
 
 	// ChatLog
 	NOT_FOUND_CHAT_LOG(HttpStatus.NOT_FOUND, "채팅이 존재하지 않습니다."),
+	FORBIDDEN_CHAT_LOG(HttpStatus.FORBIDDEN, "채팅에 대한 권한이 없습니다."),
 
 	// ChatRoom
 	NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ErrorCode.java
@@ -2,78 +2,9 @@ package codesquard.app.api.errors.errorcode;
 
 import org.springframework.http.HttpStatus;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+public interface ErrorCode {
 
-@Getter
-@RequiredArgsConstructor
-public enum ErrorCode {
-	// Category
-	NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리를 찾을 수 없습니다."),
+	HttpStatus getHttpStatus();
 
-	// Image
-	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
-	NOT_REMOVE_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최소 1개 이상 존재해야 합니다."),
-	NOT_FOUND_IMAGE_URL(HttpStatus.NOT_FOUND, "해당 이미지 URL이 존재하지 않습니다."),
-	FILE_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력에 실패했습니다."),
-	EMPTY_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "상품에 대한 이미지가 없습니다."),
-	FAIL_REMOVE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제가 실패하였습니다."),
-
-	// Item
-	INVALID_STATUS(HttpStatus.BAD_REQUEST, "상태는 판매중, 예약중, 판매완료만 들어올 수 있습니다."),
-	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
-	ITEM_FORBIDDEN(HttpStatus.FORBIDDEN, "상품에 대한 권한이 없습니다."),
-
-	// JWT
-	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
-	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
-	EXPIRE_TOKEN(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다."),
-
-	// Member
-	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾지 못하였습니다."),
-	ALREADY_EXIST_ID(HttpStatus.CONFLICT, "중복된 아이디입니다."),
-
-	// MemberTown
-	MAXIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "회원이 가질 수 있는 개수(최대2개)를 초과하였습니다."),
-	MINIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "동네는 최소 1개 이상 선택해야 해요. 새로운 동네를 등록한 후 삭제해주세요."),
-	UNREGISTERED_ADDRESS_TO_REMOVE(HttpStatus.BAD_REQUEST, "등록되지 않은 동네를 삭제할 수 없습니다."),
-	NOT_SELECT_UNREGISTERED_MEMBER_TOWN(HttpStatus.BAD_REQUEST, "회원이 등록한 동네만 선택할 수 있습니다."),
-	NOT_FOUND_MEMBER_TOWN(HttpStatus.NOT_FOUND, "회원 동네를 찾을 수 없습니다."),
-	ALREADY_ADDRESS_NAME(HttpStatus.CONFLICT, "이미 존재하는 동네입니다."),
-	FAIL_REMOVE_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "동네 삭제를 실패하였습니다."),
-
-	// Oauth
-	WRONG_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인가 코드입니다."),
-	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "provider를 찾을 수 없습니다."),
-	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
-	NOT_LOGIN_STATE(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
-	FAIL_LOGIN(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),
-	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다."),
-
-	// Region
-	NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "주소를 찾지 못하였습니다."),
-
-	// Sales
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다."),
-
-	// Wish
-	DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "이미 처리된 요청입니다."),
-
-	// ChatLog
-	NOT_FOUND_CHAT_LOG(HttpStatus.NOT_FOUND, "채팅이 존재하지 않습니다."),
-	FORBIDDEN_CHAT_LOG(HttpStatus.FORBIDDEN, "채팅에 대한 권한이 없습니다."),
-
-	// ChatRoom
-	NOT_FOUND_CHATROOM(HttpStatus.NOT_FOUND, "채팅방을 찾을 수 없습니다.");
-
-	private final HttpStatus httpStatus;
-	private final String message;
-
-	@Override
-	public String toString() {
-		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "에러 코드", this.getClass().getSimpleName(),
-			name(),
-			httpStatus,
-			message);
-	}
+	String getMessage();
 }

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ImageErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ImageErrorCode.java
@@ -1,0 +1,29 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ImageErrorCode implements ErrorCode {
+	INVALID_FILE_EXTENSION(HttpStatus.BAD_REQUEST, "지원하지 않는 파일 확장자입니다."),
+	NOT_REMOVE_IMAGES(HttpStatus.BAD_REQUEST, "이미지는 최소 1개 이상 존재해야 합니다."),
+	NOT_FOUND_IMAGE_URL(HttpStatus.NOT_FOUND, "해당 이미지 URL이 존재하지 않습니다."),
+	FILE_IO_EXCEPTION(HttpStatus.INTERNAL_SERVER_ERROR, "파일 입출력에 실패했습니다."),
+	EMPTY_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "상품에 대한 이미지가 없습니다."),
+	FAIL_REMOVE_IMAGE(HttpStatus.INTERNAL_SERVER_ERROR, "이미지 삭제가 실패하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "이미지 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/ItemErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/ItemErrorCode.java
@@ -1,0 +1,27 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ItemErrorCode implements ErrorCode {
+
+	INVALID_STATUS(HttpStatus.BAD_REQUEST, "상태는 판매중, 예약중, 판매완료만 들어올 수 있습니다."),
+	ITEM_NOT_FOUND(HttpStatus.NOT_FOUND, "상품을 찾을 수 없습니다."),
+	ITEM_FORBIDDEN(HttpStatus.FORBIDDEN, "상품에 대한 권한이 없습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "상품 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/JwtErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/JwtErrorCode.java
@@ -1,0 +1,27 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum JwtErrorCode implements ErrorCode {
+
+	INVALID_TOKEN(HttpStatus.BAD_REQUEST, "유효하지 않은 토큰입니다."),
+	EMPTY_TOKEN(HttpStatus.UNAUTHORIZED, "토큰이 존재하지 않습니다."),
+	EXPIRE_TOKEN(HttpStatus.FORBIDDEN, "토큰이 만료되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "JWT 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberErrorCode.java
@@ -1,0 +1,26 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberErrorCode implements ErrorCode {
+
+	NOT_FOUND_MEMBER(HttpStatus.NOT_FOUND, "회원을 찾지 못하였습니다."),
+	ALREADY_EXIST_ID(HttpStatus.CONFLICT, "중복된 아이디입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "회원 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/MemberTownErrorCode.java
@@ -1,0 +1,31 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberTownErrorCode implements ErrorCode {
+
+	MAXIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "회원이 가질 수 있는 개수(최대2개)를 초과하였습니다."),
+	MINIMUM_MEMBER_TOWN_SIZE(HttpStatus.BAD_REQUEST, "동네는 최소 1개 이상 선택해야 해요. 새로운 동네를 등록한 후 삭제해주세요."),
+	UNREGISTERED_ADDRESS_TO_REMOVE(HttpStatus.BAD_REQUEST, "등록되지 않은 동네를 삭제할 수 없습니다."),
+	NOT_SELECT_UNREGISTERED_MEMBER_TOWN(HttpStatus.BAD_REQUEST, "회원이 등록한 동네만 선택할 수 있습니다."),
+	NOT_FOUND_MEMBER_TOWN(HttpStatus.NOT_FOUND, "회원 동네를 찾을 수 없습니다."),
+	ALREADY_ADDRESS_NAME(HttpStatus.CONFLICT, "이미 존재하는 동네입니다."),
+	FAIL_REMOVE_ADDRESS(HttpStatus.INTERNAL_SERVER_ERROR, "동네 삭제를 실패하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "회원 동네 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
@@ -1,0 +1,30 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthErrorCode implements ErrorCode {
+
+	WRONG_AUTHORIZATION_CODE(HttpStatus.BAD_REQUEST, "잘못된 인가 코드입니다."),
+	NOT_FOUND_PROVIDER(HttpStatus.NOT_FOUND, "provider를 찾을 수 없습니다."),
+	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
+	NOT_LOGIN_STATE(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
+	FAIL_LOGIN(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),
+	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "Oauth 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/OauthErrorCode.java
@@ -14,7 +14,8 @@ public enum OauthErrorCode implements ErrorCode {
 	ALREADY_LOGOUT(HttpStatus.UNAUTHORIZED, "이미 로그아웃 상태입니다."),
 	NOT_LOGIN_STATE(HttpStatus.UNAUTHORIZED, "로그인 상태가 아닙니다."),
 	FAIL_LOGIN(HttpStatus.UNAUTHORIZED, "로그인 정보가 일치하지 않습니다."),
-	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다.");
+	ALREADY_SIGNUP(HttpStatus.UNAUTHORIZED, "이미 회원가입된 상태입니다."),
+	FAIL_ACCESS_TOKEN(HttpStatus.UNAUTHORIZED, "액세스 토큰 발급에 실패하였습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String message;

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/RegionErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/RegionErrorCode.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionErrorCode implements ErrorCode {
+
+	NOT_FOUND_REGION(HttpStatus.NOT_FOUND, "주소를 찾지 못하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "지역 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/SalesErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/SalesErrorCode.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SalesErrorCode implements ErrorCode {
+
+	INVALID_SALES_PARAMETER(HttpStatus.BAD_REQUEST, "잘못된 요청입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "판매내역 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/errorcode/WishErrorCode.java
+++ b/backend/src/main/java/codesquard/app/api/errors/errorcode/WishErrorCode.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.errors.errorcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WishErrorCode implements ErrorCode {
+
+	DUPLICATED_REQUEST(HttpStatus.BAD_REQUEST, "이미 처리된 요청입니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "관심상품 에러 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/errors/exception/OauthException.java
+++ b/backend/src/main/java/codesquard/app/api/errors/exception/OauthException.java
@@ -1,0 +1,14 @@
+package codesquard.app.api.errors.exception;
+
+import codesquard.app.api.errors.errorcode.ErrorCode;
+
+public class OauthException extends SecondHandException {
+
+	public OauthException(ErrorCode errorCode) {
+		super(errorCode);
+	}
+
+	public OauthException(ErrorCode errorCode, String message) {
+		super(errorCode, message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -26,6 +26,7 @@ import codesquard.app.api.item.request.ItemStatusModifyRequest;
 import codesquard.app.api.item.response.ItemDetailResponse;
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.ItemSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
@@ -46,15 +47,16 @@ public class ItemController {
 		@RequestPart("thumbnailImage") MultipartFile thumbnail,
 		@AuthPrincipal Principal principal) {
 		itemService.register(request, itemImage, thumbnail, principal.getMemberId());
-		return ApiResponse.created("상품 등록이 완료되었습니다.", null);
+		return ApiResponse.success(ItemSuccessCode.CREATED_ITEM);
 	}
 
 	@GetMapping
-	public ApiResponse<ItemResponses> findAll(@RequestParam String region,
-		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor,
+	public ApiResponse<ItemResponses> findAll(
+		@RequestParam String region,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor,
 		@RequestParam(required = false) Long categoryId) {
-		return ApiResponse.ok("상품 목록 조회에 성공하였습니다.",
-			itemService.findAll(region, size, cursor, categoryId));
+		return ApiResponse.success(ItemSuccessCode.OK_ITEMS, itemService.findAll(region, size, cursor, categoryId));
 	}
 
 	@GetMapping("/{itemId}")
@@ -62,7 +64,7 @@ public class ItemController {
 		@AuthPrincipal Principal principal) {
 		ItemDetailResponse response = itemService.findDetailItemBy(itemId, principal);
 		log.debug("상품 상세 조회 결과 : {}", response);
-		return ApiResponse.ok("상품 상세 조회에 성공하였습니다.", response);
+		return ApiResponse.success(ItemSuccessCode.OK_DETAILED_ITEM, response);
 	}
 
 	@PatchMapping("/{itemId}")
@@ -72,19 +74,20 @@ public class ItemController {
 		@RequestPart(value = "thumbnailImage", required = false) MultipartFile thumbnailImage,
 		@AuthPrincipal Principal principal) {
 		itemService.modifyItem(itemId, request, addImages, thumbnailImage, principal);
-		return ApiResponse.ok("상품 수정을 완료하였습니다.", null);
+		return ApiResponse.success(ItemSuccessCode.OK_MODIFIED_ITEM);
 	}
 
 	@PutMapping("/{itemId}/status")
-	public ApiResponse<Void> modifyItemStatus(@PathVariable Long itemId, @RequestBody ItemStatusModifyRequest request,
+	public ApiResponse<Void> modifyItemStatus(@PathVariable Long itemId,
+		@RequestBody ItemStatusModifyRequest request,
 		@AuthPrincipal Principal principal) {
 		itemService.changeItemStatus(itemId, request.getStatus(), principal);
-		return ApiResponse.ok("상품 상태 변경에 성공하였습니다.", null);
+		return ApiResponse.success(ItemSuccessCode.OK_MODIFIED_STATUS_ITEM);
 	}
 
 	@DeleteMapping("/{itemId}")
 	public ApiResponse<Void> deleteItem(@PathVariable Long itemId, @AuthPrincipal Principal principal) {
 		itemService.deleteItem(itemId, principal);
-		return ApiResponse.ok("상품 삭제가 완료되었습니다.", null);
+		return ApiResponse.success(ItemSuccessCode.OK_DELETED_ITEM);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/item/ItemController.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemController.java
@@ -77,7 +77,7 @@ public class ItemController {
 
 	@PutMapping("/{itemId}/status")
 	public ApiResponse<Void> modifyItemStatus(@PathVariable Long itemId, @RequestBody ItemStatusModifyRequest request,
-		@PathVariable Principal principal) {
+		@AuthPrincipal Principal principal) {
 		itemService.changeItemStatus(itemId, request.getStatus(), principal);
 		return ApiResponse.ok("상품 상태 변경에 성공하였습니다.", null);
 	}

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.CategoryErrorCode;
+import codesquard.app.api.errors.errorcode.ImageErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.image.ImageService;
@@ -85,12 +87,12 @@ public class ItemService {
 	public void changeItemStatus(Long itemId, ItemStatus status, Principal principal) {
 		log.info("상품 상태 변경 서비스 요청 : itemId={}, status={}", itemId, status);
 		Item item = itemRepository.findById(itemId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 		if (item.isSeller(principal.getMemberId())) {
 			item.changeStatus(status);
 			log.info("상품 상태 변경 결과 : item={}", item);
 		} else {
-			new BadRequestException(ErrorCode.ITEM_FORBIDDEN);
+			new BadRequestException(ItemErrorCode.ITEM_FORBIDDEN);
 		}
 	}
 
@@ -98,7 +100,7 @@ public class ItemService {
 		log.info("상품 상세 조회 서비스 요청, 상품 등록번호 : {}, 로그인 회원의 등록번호 : {}", itemId, principal.getMemberId());
 		itemViewRedisService.addViewCount(itemId, principal);
 		Item item = itemRepository.findById(itemId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 
 		List<Image> images = imageRepository.findAllByItemId(itemId);
 		List<String> imageUrls = images.stream()
@@ -147,7 +149,7 @@ public class ItemService {
 
 	private Category findCategoryBy(Long categoryId) {
 		return categoryRepository.findById(categoryId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_CATEGORY));
+			.orElseThrow(() -> new NotFoundResourceException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 	}
 
 	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumbnailUrl) {
@@ -189,7 +191,7 @@ public class ItemService {
 	private int deleteImages(Long itemId, List<String> deleteImageUrls) {
 		int currentImageSize = imageRepository.countImageByItemId(itemId);
 		if (currentImageSize <= deleteImageUrls.size()) {
-			throw new BadRequestException(ErrorCode.NOT_REMOVE_IMAGES);
+			throw new BadRequestException(ImageErrorCode.NOT_REMOVE_IMAGES);
 		}
 		return imageRepository.deleteImagesByItemIdAndImageUrlIn(itemId, deleteImageUrls);
 	}
@@ -200,7 +202,7 @@ public class ItemService {
 
 	private Item findItemByItemIdAndMemberId(Long itemId, Long memberId) {
 		return itemRepository.findItemByIdAndMemberId(itemId, memberId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 	}
 
 	@Transactional

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -108,11 +108,11 @@ public class ItemService {
 		boolean isInWishList = wishRepository.existsByMemberIdAndItemId(principal.getMemberId(), itemId);
 
 		if (item.isSeller(principal.getMemberId())) {
-			Long chatRoomId = chatRoomRepository.findByItemIdAndMemberId(itemId, principal.getMemberId())
-				.orElse(null);
-			return ItemDetailResponse.toSeller(item, principal.getMemberId(), imageUrls, isInWishList, chatRoomId);
+			return ItemDetailResponse.toSeller(item, principal.getMemberId(), imageUrls, isInWishList);
 		}
-		return ItemDetailResponse.toBuyer(item, principal.getMemberId(), imageUrls, isInWishList);
+		Long chatRoomId = chatRoomRepository.findByItemIdAndMemberId(itemId, principal.getMemberId())
+			.orElse(null);
+		return ItemDetailResponse.toBuyer(item, principal.getMemberId(), imageUrls, isInWishList, chatRoomId);
 	}
 
 	@Transactional

--- a/backend/src/main/java/codesquard/app/api/item/ItemService.java
+++ b/backend/src/main/java/codesquard/app/api/item/ItemService.java
@@ -33,6 +33,7 @@ import codesquard.app.domain.item.ItemStatus;
 import codesquard.app.domain.member.Member;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.pagination.PaginationUtils;
+import codesquard.app.domain.wish.Wish;
 import codesquard.app.domain.wish.WishRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -153,18 +154,15 @@ public class ItemService {
 	}
 
 	private String updateThumnail(Item item, MultipartFile thumbnailFile, String thumbnailUrl) {
-		// 상품 게시글 수정시 수정하고자 하는 썸네일 파일이 없다면 기존 상품 게시글의 썸네일을 사용합니다.
 		if (thumbnailFile == null) {
 			return item.getThumbnailUrl();
 		}
 
-		// 상품 게시글 수정시 수정하고자 하는 썸네일 파일이 있다면 썸네일 사진을 교체합니다.
 		if (!thumbnailFile.isEmpty()) {
 			String thumbnail = updateNewThumnail(item.getId(), thumbnailFile);
 			return updateThumbnailStatus(thumbnail, item);
 		}
 
-		// 상품 게시글 수정시 수정하고자 하는 썸네일 파일이 기존 이미지 사진들중 하나인 경우 해당 사진으로 썸네일을 교체합니다.
 		return updateThumbnailStatus(thumbnailUrl, item);
 	}
 
@@ -219,7 +217,10 @@ public class ItemService {
 
 	private void deleteAllRelatedItem(Long itemId) {
 		imageRepository.deleteByItemId(itemId);
-		wishRepository.deleteByItemId(itemId);
+		List<Long> wishIds = wishRepository.findByItemId(itemId).stream()
+			.map(Wish::getId)
+			.collect(Collectors.toUnmodifiableList());
+		wishRepository.deleteAllByIdIn(wishIds);
 		chatRoomRepository.deleteByItemId(itemId);
 		itemRepository.deleteById(itemId);
 	}

--- a/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
+++ b/backend/src/main/java/codesquard/app/api/item/response/ItemDetailResponse.java
@@ -51,27 +51,6 @@ public class ItemDetailResponse implements Serializable {
 	}
 
 	public static ItemDetailResponse toBuyer(Item item, Long loginMemberId, List<String> imageUrls,
-		boolean isInWishList) {
-		Member seller = item.getMember();
-		boolean isSeller = seller.equalId(loginMemberId);
-		return ItemDetailResponse.builder()
-			.isSeller(isSeller)
-			.imageUrls(imageUrls)
-			.seller(seller.getLoginId())
-			.status(item.getStatus().getStatus())
-			.title(item.getTitle())
-			.categoryName(item.getCategory().getName())
-			.createdAt(item.getCreatedAt())
-			.content(item.getContent())
-			.chatCount(item.getChatCount())
-			.wishCount(item.getWishCount())
-			.viewCount(item.getViewCount())
-			.price(item.getPrice())
-			.isInWishList(isInWishList)
-			.build();
-	}
-
-	public static ItemDetailResponse toSeller(Item item, Long loginMemberId, List<String> imageUrls,
 		boolean isInWishList, Long chatRoomId) {
 		Member seller = item.getMember();
 		boolean isSeller = seller.equalId(loginMemberId);
@@ -90,6 +69,27 @@ public class ItemDetailResponse implements Serializable {
 			.price(item.getPrice())
 			.isInWishList(isInWishList)
 			.chatRoomId(chatRoomId)
+			.build();
+	}
+
+	public static ItemDetailResponse toSeller(Item item, Long loginMemberId, List<String> imageUrls,
+		boolean isInWishList) {
+		Member seller = item.getMember();
+		boolean isSeller = seller.equalId(loginMemberId);
+		return ItemDetailResponse.builder()
+			.isSeller(isSeller)
+			.imageUrls(imageUrls)
+			.seller(seller.getLoginId())
+			.status(item.getStatus().getStatus())
+			.title(item.getTitle())
+			.categoryName(item.getCategory().getName())
+			.createdAt(item.getCreatedAt())
+			.content(item.getContent())
+			.chatCount(item.getChatCount())
+			.wishCount(item.getWishCount())
+			.viewCount(item.getViewCount())
+			.price(item.getPrice())
+			.isInWishList(isInWishList)
 			.build();
 	}
 

--- a/backend/src/main/java/codesquard/app/api/member/MemberController.java
+++ b/backend/src/main/java/codesquard/app/api/member/MemberController.java
@@ -13,6 +13,7 @@ import codesquard.app.api.member.response.MemberProfileResponse;
 import codesquard.app.api.membertown.MemberTownService;
 import codesquard.app.api.membertown.response.MemberTownListResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.MemberSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
@@ -28,12 +29,12 @@ public class MemberController {
 	@PutMapping(value = "/{loginId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
 	public ApiResponse<MemberProfileResponse> modifyProfileImage(@RequestPart MultipartFile updateImageFile,
 		@PathVariable String loginId) {
-		return ApiResponse.ok("프로필 사진이 수정되었습니다.",
+		return ApiResponse.success(MemberSuccessCode.OK_MODIFIED_PROFILE_IMAGE,
 			memberService.modifyProfileImage(loginId, updateImageFile));
 	}
 
 	@GetMapping(value = "/regions")
 	public ApiResponse<MemberTownListResponse> readAllMemberTowns(@AuthPrincipal Principal principal) {
-		return ApiResponse.ok("회원 동네 목록 조회를 완료하였습니다.", memberTownService.readAll(principal));
+		return ApiResponse.success(MemberSuccessCode.OK_MEMBER_TOWNS, memberTownService.readAll(principal));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/member/MemberService.java
+++ b/backend/src/main/java/codesquard/app/api/member/MemberService.java
@@ -4,7 +4,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.image.ImageService;
 import codesquard.app.api.member.response.MemberProfileResponse;
@@ -22,7 +22,7 @@ public class MemberService {
 	@Transactional
 	public MemberProfileResponse modifyProfileImage(String loginId, MultipartFile updateImageFile) {
 		Member member = memberRepository.findMemberByLoginId(loginId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 		imageService.deleteImage(member.getAvatarUrl());
 		String avatarUrl = imageService.uploadImage(updateImageFile);
 		member.changeAvatarUrl(avatarUrl);
@@ -31,6 +31,6 @@ public class MemberService {
 
 	public Member findMemberByLoginId(String loginId) {
 		return memberRepository.findMemberByLoginId(loginId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownRestController.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownRestController.java
@@ -15,6 +15,7 @@ import codesquard.app.api.membertown.request.MemberTownAddRequest;
 import codesquard.app.api.membertown.request.MemberTownRemoveRequest;
 import codesquard.app.api.region.request.RegionSelectionRequest;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.MemberTownSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
@@ -33,14 +34,14 @@ public class MemberTownRestController {
 	public ApiResponse<Void> addMemberTown(@AuthPrincipal Principal principal,
 		@Valid @RequestBody MemberTownAddRequest request) {
 		memberTownService.addMemberTown(principal, request);
-		return ApiResponse.created("동네 추가에 성공하였습니다.", null);
+		return ApiResponse.success(MemberTownSuccessCode.CREATED_MEMBER_TOWN);
 	}
 
 	@DeleteMapping
 	public ApiResponse<Void> removeMemberTown(@AuthPrincipal Principal principal,
 		@Valid @RequestBody MemberTownRemoveRequest request) {
 		memberTownService.removeMemberTown(principal, request);
-		return ApiResponse.ok("동네 삭제에 성공하였습니다.", null);
+		return ApiResponse.success(MemberTownSuccessCode.OK_DELETED_MEMBER_TOWN);
 	}
 
 	@PutMapping
@@ -48,6 +49,6 @@ public class MemberTownRestController {
 		@Valid @RequestBody RegionSelectionRequest request,
 		@AuthPrincipal Principal principal) {
 		memberTownService.selectRegion(request, principal);
-		return ApiResponse.ok("지역 선택을 완료하였습니다.", null);
+		return ApiResponse.success(MemberTownSuccessCode.OK_SELECTED_MEMBER_TOWN);
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
@@ -6,7 +6,9 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.MemberTownErrorCode;
+import codesquard.app.api.errors.errorcode.RegionErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.membertown.request.MemberTownAddRequest;
@@ -71,18 +73,18 @@ public class MemberTownService {
 	private void changeIsSelectedWithRemainMemberTown(Principal principal) {
 		MemberTown remainMemberTown = memberTownRepository.findAllByMemberId(principal.getMemberId()).stream()
 			.findAny()
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER_TOWN));
+			.orElseThrow(() -> new NotFoundResourceException(MemberTownErrorCode.NOT_FOUND_MEMBER_TOWN));
 		remainMemberTown.changeIsSelected(true);
 	}
 
 	private Region getAddressIdBy(Long addressId) {
 		return regionRepository.findById(addressId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_REGION));
+			.orElseThrow(() -> new NotFoundResourceException(RegionErrorCode.NOT_FOUND_REGION));
 	}
 
 	private Member findMemberBy(Principal principal) {
 		return memberRepository.findById(principal.getMemberId())
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 	}
 
 	@Transactional
@@ -101,13 +103,13 @@ public class MemberTownService {
 
 	private void validateRegisteredMemberTown(Long regionId, Long memberId) {
 		if (memberTownRepository.findMemberTownByMemberIdAndRegionId(memberId, regionId).isEmpty()) {
-			throw new BadRequestException(ErrorCode.NOT_SELECT_UNREGISTERED_MEMBER_TOWN);
+			throw new BadRequestException(MemberTownErrorCode.NOT_SELECT_UNREGISTERED_MEMBER_TOWN);
 		}
 	}
 
 	private void validateExistRegion(Long regionId) {
 		if (regionRepository.findById(regionId).isEmpty()) {
-			throw new NotFoundResourceException(ErrorCode.NOT_FOUND_REGION);
+			throw new NotFoundResourceException(RegionErrorCode.NOT_FOUND_REGION);
 		}
 	}
 

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownService.java
@@ -113,7 +113,6 @@ public class MemberTownService {
 		}
 	}
 
-	@Transactional(readOnly = true)
 	public MemberTownListResponse readAll(Principal principal) {
 		List<MemberTownItemResponse> itemResponses = memberTownRepository.findAllByMemberId(principal.getMemberId())
 			.stream()

--- a/backend/src/main/java/codesquard/app/api/membertown/MemberTownValidator.java
+++ b/backend/src/main/java/codesquard/app/api/membertown/MemberTownValidator.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import org.springframework.stereotype.Component;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberTownErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.ConflictException;
 import codesquard.app.domain.membertown.MemberTown;
@@ -34,7 +34,7 @@ public class MemberTownValidator {
 			.anyMatch(r -> r.equals(region));
 
 		if (match) {
-			throw new ConflictException(ErrorCode.ALREADY_ADDRESS_NAME);
+			throw new ConflictException(MemberTownErrorCode.ALREADY_ADDRESS_NAME);
 		}
 	}
 
@@ -44,19 +44,19 @@ public class MemberTownValidator {
 			.noneMatch(r -> r.equals(region));
 
 		if (noneMatch) {
-			throw new BadRequestException(ErrorCode.UNREGISTERED_ADDRESS_TO_REMOVE);
+			throw new BadRequestException(MemberTownErrorCode.UNREGISTERED_ADDRESS_TO_REMOVE);
 		}
 	}
 
 	private void validateMaximumMemberTownSize(List<MemberTown> memberTowns) {
 		if (memberTowns.size() > MAXIMUM_MEMBER_TOWN_SIZE) {
-			throw new BadRequestException(ErrorCode.MAXIMUM_MEMBER_TOWN_SIZE);
+			throw new BadRequestException(MemberTownErrorCode.MAXIMUM_MEMBER_TOWN_SIZE);
 		}
 	}
 
 	private void validateMinimumMemberTownSize(List<MemberTown> memberTowns) {
 		if (memberTowns.size() <= MINIMUM_MEMBER_TOWN_SIZE) {
-			throw new BadRequestException(ErrorCode.MINIMUM_MEMBER_TOWN_SIZE);
+			throw new BadRequestException(MemberTownErrorCode.MINIMUM_MEMBER_TOWN_SIZE);
 		}
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthRestController.java
@@ -27,6 +27,7 @@ import codesquard.app.api.oauth.response.OauthLoginResponse;
 import codesquard.app.api.oauth.response.OauthRefreshResponse;
 import codesquard.app.api.oauth.response.OauthSignUpResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.OauthSuccessCode;
 import codesquard.app.config.ValidationSequence;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +53,7 @@ public class OauthRestController {
 			profile, request);
 
 		oauthService.signUp(profile, request, provider, code, redirectUrl);
-		return ApiResponse.created("회원가입에 성공하였습니다.", null);
+		return ApiResponse.success(OauthSuccessCode.CREATED_SIGNUP);
 	}
 
 	@PostMapping(value = "/{provider}/login")
@@ -62,7 +63,7 @@ public class OauthRestController {
 		@RequestParam(value = "redirectUrl", required = false) String redirectUrl,
 		@Validated(ValidationSequence.class) @RequestBody OauthLoginRequest request) {
 		OauthLoginResponse response = oauthService.login(request, provider, code, LocalDateTime.now(), redirectUrl);
-		return ApiResponse.of(OK, "로그인에 성공하였습니다.", response);
+		return ApiResponse.success(OauthSuccessCode.OK_LOGIN, response);
 	}
 
 	@PostMapping(value = "/logout")
@@ -70,7 +71,7 @@ public class OauthRestController {
 		@RequestBody OauthLogoutRequest request) {
 		log.info("로그아웃 요청 입력 : acessToken={}, request={}", accessToken, request);
 		oauthService.logout(accessToken, request);
-		return ApiResponse.ok("로그아웃에 성공하였습니다.", null);
+		return ApiResponse.success(OauthSuccessCode.OK_LOGOUT);
 	}
 
 	@ResponseStatus(OK)
@@ -80,7 +81,7 @@ public class OauthRestController {
 
 		OauthRefreshResponse response = oauthService.refreshAccessToken(request, LocalDateTime.now());
 		log.debug("리프레시 토큰 API 응답 : {}", response);
-		return ApiResponse.ok("액세스 토큰 갱신에 성공하였습니다.", response);
+		return ApiResponse.success(OauthSuccessCode.OK_REFRESH_TOKEN, response);
 	}
 
 }

--- a/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
+++ b/backend/src/main/java/codesquard/app/api/oauth/OauthService.java
@@ -9,7 +9,9 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
+import codesquard.app.api.errors.errorcode.RegionErrorCode;
 import codesquard.app.api.errors.exception.ConflictException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.errors.exception.SecondHandException;
@@ -80,7 +82,7 @@ public class OauthService {
 		int otherRegionStartIdx = 1;
 		int frontRegion = 0;
 		Region selectedRegion = regionRepository.findById(addressIds.get(frontRegion))
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_REGION));
+			.orElseThrow(() -> new NotFoundResourceException(RegionErrorCode.NOT_FOUND_REGION));
 		List<Region> notSelectedRegion = regionRepository.findAllById(
 			addressIds.subList(otherRegionStartIdx, addressIds.size()));
 
@@ -97,13 +99,13 @@ public class OauthService {
 
 	private void validateDuplicateLoginId(String loginId) {
 		if (memberRepository.existsMemberByLoginId(loginId)) {
-			throw new ConflictException(ErrorCode.ALREADY_EXIST_ID);
+			throw new ConflictException(MemberErrorCode.ALREADY_EXIST_ID);
 		}
 	}
 
 	private void validateMultipleSignUp(String email) {
 		if (memberRepository.existsMemberByEmail(email)) {
-			throw new UnAuthorizationException(ErrorCode.ALREADY_SIGNUP);
+			throw new UnAuthorizationException(OauthErrorCode.ALREADY_SIGNUP);
 		}
 	}
 
@@ -145,7 +147,7 @@ public class OauthService {
 		String loginId = request.getLoginId();
 		String email = userProfileResponse.getEmail();
 		return memberRepository.findMemberByLoginIdAndEmail(loginId, email)
-			.orElseThrow(() -> new UnAuthorizationException(ErrorCode.FAIL_LOGIN));
+			.orElseThrow(() -> new UnAuthorizationException(OauthErrorCode.FAIL_LOGIN));
 	}
 
 	public void logout(String accessToken, OauthLogoutRequest request) {
@@ -192,7 +194,7 @@ public class OauthService {
 		String email = redisService.findEmailBy(refreshToken);
 		log.debug("findEmailByRefreshToken 결과 : email={}", email);
 		Member member = memberRepository.findMemberByEmail(email)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 		log.debug("findMemberByEmail 결과 : member={}", member);
 
 		Jwt jwt = jwtProvider.createJwtWithRefreshTokenBasedOnMember(member, refreshToken, now);

--- a/backend/src/main/java/codesquard/app/api/redis/OauthRedisService.java
+++ b/backend/src/main/java/codesquard/app/api/redis/OauthRedisService.java
@@ -9,7 +9,8 @@ import org.apache.logging.log4j.util.Strings;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.UnAuthorizationException;
 import codesquard.app.domain.jwt.Jwt;
@@ -32,13 +33,13 @@ public class OauthRedisService {
 	public String findEmailBy(String refreshToken) {
 		Set<String> keys = redisTemplate.keys(REFRESH_TOKEN_PATTERN.pattern());
 		if (keys == null) {
-			throw new UnAuthorizationException(ErrorCode.EMPTY_TOKEN);
+			throw new UnAuthorizationException(JwtErrorCode.EMPTY_TOKEN);
 		}
 		return keys.stream()
 			.filter(key -> Objects.equals(redisTemplate.opsForValue().get(key), refreshToken))
 			.findAny()
 			.map(email -> email.replace(REFRESH_TOKEN_PREFIX, Strings.EMPTY))
-			.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_TOKEN));
+			.orElseThrow(() -> new BadRequestException(JwtErrorCode.INVALID_TOKEN));
 	}
 
 	public void saveRefreshToken(String key, Jwt jwt) {
@@ -63,7 +64,7 @@ public class OauthRedisService {
 	public void validateAlreadyLogout(String token) {
 		String logout = redisTemplate.opsForValue().get(token);
 		if (LOGOUT.equals(logout)) {
-			throw new UnAuthorizationException(ErrorCode.NOT_LOGIN_STATE);
+			throw new UnAuthorizationException(OauthErrorCode.NOT_LOGIN_STATE);
 		}
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/region/RegionRestController.java
+++ b/backend/src/main/java/codesquard/app/api/region/RegionRestController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.region.response.RegionListResponse;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.RegionSuccessCode;
 import lombok.RequiredArgsConstructor;
 
 @RequestMapping(path = "/api/regions")
@@ -18,9 +19,9 @@ public class RegionRestController {
 
 	@GetMapping
 	public ApiResponse<RegionListResponse> findAll(
-		@RequestParam(value = "size", defaultValue = "10", required = false) int size,
-		@RequestParam(value = "cursor", required = false) Long cursor,
-		@RequestParam(value = "region", required = false) String region) {
-		return ApiResponse.ok("주소 목록 조회에 성공하였습니다.", regionService.searchBySlice(size, cursor, region));
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor,
+		@RequestParam(required = false) String region) {
+		return ApiResponse.success(RegionSuccessCode.OK_REGIONS, regionService.searchBySlice(size, cursor, region));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/response/ApiResponse.java
+++ b/backend/src/main/java/codesquard/app/api/response/ApiResponse.java
@@ -3,6 +3,7 @@ package codesquard.app.api.response;
 import org.springframework.http.HttpStatus;
 
 import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.success.successcode.SuccessCode;
 import lombok.Getter;
 
 @Getter
@@ -28,6 +29,14 @@ public class ApiResponse<T> {
 
 	public static <T> ApiResponse<T> created(String message, T data) {
 		return new ApiResponse<>(HttpStatus.CREATED, message, data);
+	}
+
+	public static <T> ApiResponse<T> success(SuccessCode code) {
+		return new ApiResponse<>(code.getHttpStatus(), code.getMessage(), null);
+	}
+
+	public static <T> ApiResponse<T> success(SuccessCode code, T data) {
+		return new ApiResponse<>(code.getHttpStatus(), code.getMessage(), data);
 	}
 
 	public static <T> ApiResponse<T> error(ErrorCode errorCode) {

--- a/backend/src/main/java/codesquard/app/api/sales/SalesItemController.java
+++ b/backend/src/main/java/codesquard/app/api/sales/SalesItemController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.SalesSuccessCode;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
 import codesquard.app.domain.sales.SalesStatus;
@@ -20,9 +21,12 @@ public class SalesItemController {
 	private final SalesItemService salesItemService;
 
 	@GetMapping
-	public ApiResponse<ItemResponses> findAll(@RequestParam(required = false, defaultValue = "all") SalesStatus status,
-		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor,
+	public ApiResponse<ItemResponses> findAll(
+		@RequestParam(required = false, defaultValue = "all") SalesStatus status,
+		@RequestParam(required = false, defaultValue = "10") int size,
+		@RequestParam(required = false) Long cursor,
 		@AuthPrincipal Principal principal) {
-		return ApiResponse.ok("판매 내역 조회에 성공하였습니다.", salesItemService.findAll(status, size, cursor, principal));
+		return ApiResponse.success(SalesSuccessCode.OK_SALES,
+			salesItemService.findAll(status, size, cursor, principal));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/success/successcode/CategorySuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/CategorySuccessCode.java
@@ -1,0 +1,24 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategorySuccessCode implements SuccessCode {
+	OK_CATEGORIES(HttpStatus.OK, "카테고리 조회에 성공하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "카테고리 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/ChatLogSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/ChatLogSuccessCode.java
@@ -1,0 +1,27 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatLogSuccessCode implements SuccessCode {
+
+	CREATED_CHAT_LOG(HttpStatus.CREATED, "메시지 전송이 완료되었습니다."),
+	OK_NOT_NEW_CHAT_LOG(HttpStatus.OK, "새로운 채팅 메시지가 존재하지 않습니다."),
+	OK_CHAT_LOGS(HttpStatus.OK, "채팅 메시지 목록 조회가 완료되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "채팅 메시지 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/ChatRoomSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/ChatRoomSuccessCode.java
@@ -1,0 +1,26 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ChatRoomSuccessCode implements SuccessCode {
+	CREATED_CHAT_ROOM(HttpStatus.CREATED, "채팅방 생성을 완료하였습니다."),
+	OK_CHAT_ROOMS(HttpStatus.OK, "채팅방 목록 조회를 완료하였습니다."),
+	OK_CHAT_ROOMS_BY_ITEMS(HttpStatus.OK, "상품에 따른 채팅방 목록 조회를 완료하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "채팅방 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/ItemSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/ItemSuccessCode.java
@@ -1,0 +1,29 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum ItemSuccessCode implements SuccessCode {
+	CREATED_ITEM(HttpStatus.CREATED, "상품 등록이 완료되었습니다."),
+	OK_ITEMS(HttpStatus.OK, "상품 목록 조회에 성공하였습니다."),
+	OK_DETAILED_ITEM(HttpStatus.OK, "상품 상세 조회에 성공하였습니다."),
+	OK_MODIFIED_ITEM(HttpStatus.OK, "상품 수정을 완료하였습니다."),
+	OK_MODIFIED_STATUS_ITEM(HttpStatus.OK, "상품 상태 변경에 성공하였습니다."),
+	OK_DELETED_ITEM(HttpStatus.OK, "상품 삭제가 완료되었습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "상품 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/MemberSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/MemberSuccessCode.java
@@ -1,0 +1,25 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberSuccessCode implements SuccessCode {
+	OK_MODIFIED_PROFILE_IMAGE(HttpStatus.OK, "프로필 사진이 수정되었습니다."),
+	OK_MEMBER_TOWNS(HttpStatus.OK, "회원 동네 목록 조회를 완료하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "회원 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/MemberTownSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/MemberTownSuccessCode.java
@@ -1,0 +1,26 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum MemberTownSuccessCode implements SuccessCode {
+	CREATED_MEMBER_TOWN(HttpStatus.CREATED, "동네 추가에 성공하였습니다."),
+	OK_DELETED_MEMBER_TOWN(HttpStatus.OK, "동네 삭제에 성공하였습니다."),
+	OK_SELECTED_MEMBER_TOWN(HttpStatus.OK, "지역 선택을 완료하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "회원 동네 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/OauthSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/OauthSuccessCode.java
@@ -1,0 +1,27 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum OauthSuccessCode implements SuccessCode {
+	CREATED_SIGNUP(HttpStatus.CREATED, "회원가입에 성공하였습니다."),
+	OK_LOGIN(HttpStatus.OK, "로그인에 성공하였습니다."),
+	OK_LOGOUT(HttpStatus.OK, "로그아웃에 성공하였습니다."),
+	OK_REFRESH_TOKEN(HttpStatus.OK, "액세스 토큰 갱신에 성공하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "Oauth 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/RegionSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/RegionSuccessCode.java
@@ -1,0 +1,24 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RegionSuccessCode implements SuccessCode {
+	OK_REGIONS(HttpStatus.OK, "주소 목록 조회에 성공하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "지역 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/SalesSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/SalesSuccessCode.java
@@ -1,0 +1,24 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SalesSuccessCode implements SuccessCode {
+	OK_SALES(HttpStatus.OK, "판매 내역 조회에 성공하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "판매내역 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/SuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/SuccessCode.java
@@ -1,0 +1,9 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+public interface SuccessCode {
+	HttpStatus getHttpStatus();
+
+	String getMessage();
+}

--- a/backend/src/main/java/codesquard/app/api/success/successcode/WishSuccessCode.java
+++ b/backend/src/main/java/codesquard/app/api/success/successcode/WishSuccessCode.java
@@ -1,0 +1,26 @@
+package codesquard.app.api.success.successcode;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum WishSuccessCode implements SuccessCode {
+	OK_MODIFIED_WISH_STATUS(HttpStatus.OK, "관심상품 변경이 완료되었습니다."),
+	OK_WISHES(HttpStatus.OK, "관심상품 조회에 성공하였습니다."),
+	OK_WISH_CATEGORIES(HttpStatus.OK, "관심상품의 카테고리 목록 조회를 완료하였습니다.");
+
+	private final HttpStatus httpStatus;
+	private final String message;
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(name=%s, httpStatus=%s, message=%s)", "관심상품 성공 코드",
+			this.getClass().getSimpleName(),
+			name(),
+			httpStatus,
+			message);
+	}
+}

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import codesquard.app.api.item.response.ItemResponses;
 import codesquard.app.api.response.ApiResponse;
+import codesquard.app.api.success.successcode.WishSuccessCode;
 import codesquard.app.api.wishitem.response.WishCategoryListResponse;
 import codesquard.app.domain.oauth.support.AuthPrincipal;
 import codesquard.app.domain.oauth.support.Principal;
@@ -28,19 +29,20 @@ public class WishItemController {
 	public ApiResponse<Void> wishStatus(@PathVariable Long itemId, @RequestParam WishStatus wish,
 		@AuthPrincipal Principal principal) {
 		wishItemService.changeWishStatus(itemId, principal.getMemberId(), wish);
-		return ApiResponse.ok("관심상품 변경이 완료되었습니다.", null);
+		return ApiResponse.success(WishSuccessCode.OK_MODIFIED_WISH_STATUS);
 	}
 
 	@GetMapping
 	public ApiResponse<ItemResponses> findAll(@RequestParam(required = false) Long categoryId,
 		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor,
 		@AuthPrincipal Principal principal) {
-		return ApiResponse.ok("관심상품 조회에 성공하였습니다.", wishItemService.findAll(categoryId, size, cursor, principal));
+		return ApiResponse.success(WishSuccessCode.OK_WISHES,
+			wishItemService.findAll(categoryId, size, cursor, principal));
 	}
 
 	@GetMapping("/categories")
 	public ApiResponse<WishCategoryListResponse> readWishCategories(@AuthPrincipal Principal principal) {
 		log.info("관심 상품들의 카테고리 목록 요청 : {}", principal);
-		return ApiResponse.ok("관심상품의 카테고리 목록 조회를 완료하였습니다.", wishItemService.readWishCategories(principal));
+		return ApiResponse.success(WishSuccessCode.OK_WISH_CATEGORIES, wishItemService.readWishCategories(principal));
 	}
 }

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemController.java
@@ -33,8 +33,9 @@ public class WishItemController {
 
 	@GetMapping
 	public ApiResponse<ItemResponses> findAll(@RequestParam(required = false) Long categoryId,
-		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor) {
-		return ApiResponse.ok("관심상품 조회에 성공하였습니다.", wishItemService.findAll(categoryId, size, cursor));
+		@RequestParam(required = false, defaultValue = "10") int size, @RequestParam(required = false) Long cursor,
+		@AuthPrincipal Principal principal) {
+		return ApiResponse.ok("관심상품 조회에 성공하였습니다.", wishItemService.findAll(categoryId, size, cursor, principal));
 	}
 
 	@GetMapping("/categories")

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -66,8 +66,9 @@ public class WishItemService {
 		wishRepository.deleteByItemId(itemId);
 	}
 
-	public ItemResponses findAll(Long categoryId, int size, Long cursor) {
-		Slice<ItemResponse> itemResponses = wishPaginationRepository.findAll(categoryId, size, cursor);
+	public ItemResponses findAll(Long categoryId, int size, Long cursor, Principal principal) {
+		Long memberId = principal.getMemberId();
+		Slice<ItemResponse> itemResponses = wishPaginationRepository.findAll(categoryId, size, cursor, memberId);
 		return PaginationUtils.getItemResponses(itemResponses);
 	}
 

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -9,7 +9,9 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.WishErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.item.response.ItemResponse;
@@ -49,19 +51,19 @@ public class WishItemService {
 
 	private void register(Long itemId, Long memberId) {
 		Item item = itemRepository.findById(itemId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 		if (wishRepository.existsByMemberIdAndItemId(memberId, itemId)) {
-			throw new BadRequestException(ErrorCode.DUPLICATED_REQUEST);
+			throw new BadRequestException(WishErrorCode.DUPLICATED_REQUEST);
 		}
 		item.wishRegister();
 		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 		wishRepository.save(new Wish(member, item));
 	}
 
 	private void cancel(Long itemId) {
 		Item item = itemRepository.findById(itemId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 		item.wishCancel();
 		wishRepository.deleteByItemId(itemId);
 	}

--- a/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
+++ b/backend/src/main/java/codesquard/app/api/wishitem/WishItemService.java
@@ -65,7 +65,10 @@ public class WishItemService {
 		Item item = itemRepository.findById(itemId)
 			.orElseThrow(() -> new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 		item.wishCancel();
-		wishRepository.deleteByItemId(itemId);
+		List<Long> wishIds = wishRepository.findByItemId(item.getId()).stream()
+			.map(Wish::getId)
+			.collect(Collectors.toUnmodifiableList());
+		wishRepository.deleteAllByIdIn(wishIds);
 	}
 
 	public ItemResponses findAll(Long categoryId, int size, Long cursor, Principal principal) {

--- a/backend/src/main/java/codesquard/app/config/WebConfig.java
+++ b/backend/src/main/java/codesquard/app/config/WebConfig.java
@@ -30,6 +30,8 @@ import lombok.RequiredArgsConstructor;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
+	private static final int CACHE_MAX_AGES_SECONDS = 3600;
+
 	private final AuthPrincipalArgumentResolver authPrincipalArgumentResolver;
 	private final JwtProvider jwtProvider;
 	private final AuthenticationContext authenticationContext;
@@ -44,7 +46,7 @@ public class WebConfig implements WebMvcConfigurer {
 
 		WebContentInterceptor webCacheContentInterceptor = new WebContentInterceptor();
 		webCacheContentInterceptor.addCacheMapping(
-			CacheControl.maxAge(3600, TimeUnit.SECONDS).noTransform().mustRevalidate(),
+			CacheControl.maxAge(CACHE_MAX_AGES_SECONDS, TimeUnit.SECONDS).noTransform().mustRevalidate(),
 			"/api/categories", "/api/wishes/categories");
 
 		registry.addInterceptor(webCacheContentInterceptor);

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLog.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLog.java
@@ -22,6 +22,9 @@ import lombok.NoArgsConstructor;
 @Entity
 public class ChatLog {
 
+	private static final int INITIAL_READ_COUNt = 1;
+	private static final int ALL_READ = 0;
+
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
 	private Long id;
@@ -46,9 +49,9 @@ public class ChatLog {
 
 	public static ChatLog createBySender(String message, ChatRoom chatRoom, Principal sender) {
 		if (sender.isBuyer(chatRoom.getBuyer())) {
-			return new ChatLog(message, sender.getLoginId(), chatRoom.getSellerLoginId(), chatRoom, 1);
+			return new ChatLog(message, sender.getLoginId(), chatRoom.getSellerLoginId(), chatRoom, INITIAL_READ_COUNt);
 		}
-		return new ChatLog(message, sender.getLoginId(), chatRoom.getBuyerLoginId(), chatRoom, 1);
+		return new ChatLog(message, sender.getLoginId(), chatRoom.getBuyerLoginId(), chatRoom, INITIAL_READ_COUNt);
 	}
 
 	public boolean isSender(String loginId) {
@@ -56,7 +59,7 @@ public class ChatLog {
 	}
 
 	public void decreaseMessageReadCount(String readerLoginId) {
-		if (this.readCount == 0 || this.sender.equals(readerLoginId)) {
+		if (this.readCount == ALL_READ || this.sender.equals(readerLoginId)) {
 			return;
 		}
 		this.readCount--;

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogCountRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogCountRepository.java
@@ -5,6 +5,7 @@ import static codesquard.app.domain.chat.QChatRoom.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Repository;
@@ -38,8 +39,8 @@ public class ChatLogCountRepository {
 		int unreadMessageCountIdx = 1;
 		return results.stream()
 			.collect(Collectors.toMap(
-				tuple -> tuple.get(chatRoomIdIdx, Long.class),            // chatRoomId
-				tuple -> tuple.get(unreadMessageCountIdx, Long.class)    // newMessageCount
+				tuple -> tuple.get(chatRoomIdIdx, Long.class),
+				tuple -> Optional.ofNullable(tuple.get(unreadMessageCountIdx, Long.class)).orElse(0L)
 			));
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
@@ -23,7 +23,7 @@ public class ChatLogPaginationRepository {
 	public Slice<ChatLog> searchBySlice(BooleanBuilder whereBuilder, Pageable pageable) {
 		List<ChatLog> chatLogs = queryFactory.selectFrom(chatLog)
 			.where(whereBuilder)
-			.orderBy(chatLog.id.asc())
+			.orderBy(chatLog.id.asc(), chatLog.createdAt.asc())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
 		return checkLastPage(pageable, chatLogs);

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -22,5 +23,19 @@ public class ChatLogPaginationRepository {
 			.where(whereBuilder)
 			.orderBy(chatLog.id.asc(), chatLog.createdAt.asc())
 			.fetch();
+	}
+
+	public BooleanExpression greaterThanChatLogId(Long chatLogId) {
+		if (chatLogId == null) {
+			return null;
+		}
+		return chatLog.id.gt(chatLogId);
+	}
+
+	public BooleanExpression equalChatRoomId(Long chatRoomId) {
+		if (chatRoomId == null) {
+			return null;
+		}
+		return chatLog.chatRoom.id.eq(chatRoomId);
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogPaginationRepository.java
@@ -4,9 +4,6 @@ import static codesquard.app.domain.chat.QChatLog.*;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
@@ -20,23 +17,10 @@ public class ChatLogPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
 
-	public Slice<ChatLog> searchBySlice(BooleanBuilder whereBuilder, Pageable pageable) {
-		List<ChatLog> chatLogs = queryFactory.selectFrom(chatLog)
+	public List<ChatLog> searchBy(BooleanBuilder whereBuilder) {
+		return queryFactory.selectFrom(chatLog)
 			.where(whereBuilder)
 			.orderBy(chatLog.id.asc(), chatLog.createdAt.asc())
-			.limit(pageable.getPageSize() + 1)
 			.fetch();
-		return checkLastPage(pageable, chatLogs);
 	}
-
-	private Slice<ChatLog> checkLastPage(Pageable pageable, List<ChatLog> chatLogs) {
-		boolean hasNext = false;
-
-		if (chatLogs.size() > pageable.getPageSize()) {
-			hasNext = true;
-			chatLogs.remove(pageable.getPageSize());
-		}
-		return new SliceImpl<>(chatLogs, pageable, hasNext);
-	}
-
 }

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatLogRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatLogRepository.java
@@ -1,28 +1,10 @@
 package codesquard.app.domain.chat;
 
-import static codesquard.app.domain.chat.QChatLog.*;
-
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-
 public interface ChatLogRepository extends JpaRepository<ChatLog, Long> {
-
-	default BooleanExpression greaterThanChatLogId(Long chatLogId) {
-		if (chatLogId == null) {
-			return null;
-		}
-		return chatLog.id.gt(chatLogId);
-	}
-
-	default BooleanExpression equalChatRoomId(Long chatRoomId) {
-		if (chatRoomId == null) {
-			return null;
-		}
-		return chatLog.chatRoom.id.eq(chatRoomId);
-	}
 
 	Optional<ChatLog> findFirstByChatRoomIdOrderByCreatedAtDesc(Long chatRoomId);
 }

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomPaginationRepository.java
@@ -30,7 +30,6 @@ public class ChatRoomPaginationRepository {
 			.offset(pageable.getOffset())
 			.limit(pageable.getPageSize() + 1)
 			.fetch();
-		log.info("채팅방 목록 조회 결과 : {}", chatRooms);
 		return checkLastPage(pageable, chatRooms);
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomPaginationRepository.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.SliceImpl;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.BooleanBuilder;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import lombok.RequiredArgsConstructor;
@@ -43,4 +44,24 @@ public class ChatRoomPaginationRepository {
 		return new SliceImpl<>(chatRooms, pageable, hasNext);
 	}
 
+	public BooleanExpression equalItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+		return chatRoom.item.id.eq(itemId);
+	}
+
+	public BooleanExpression inItemIdsOfChatRoom(List<Long> itemIds) {
+		if (itemIds == null) {
+			return null;
+		}
+		return chatRoom.item.id.in(itemIds);
+	}
+
+	public BooleanExpression equalBuyerIdOfChatRoom(Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
+		return chatRoom.buyer.id.eq(memberId);
+	}
 }

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -1,24 +1,12 @@
 package codesquard.app.domain.chat;
 
-import static codesquard.app.domain.chat.QChatRoom.*;
-
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
-
-	default BooleanExpression equalItemId(Long itemId) {
-		if (itemId == null) {
-			return null;
-		}
-
-		return chatRoom.item.id.eq(itemId);
-	}
 
 	int deleteByItemId(Long itemId);
 

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
 
-	int deleteByItemId(Long itemId);
+	void deleteByItemId(Long itemId);
 
 	@Query("select chatRoom.id from ChatRoom chatRoom where chatRoom.item.id = :itemId and chatRoom.buyer.id = :memberId")
 	Optional<Long> findByItemIdAndMemberId(@Param("itemId") Long itemId, @Param("memberId") Long memberId);

--- a/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/chat/ChatRoomRepository.java
@@ -1,12 +1,24 @@
 package codesquard.app.domain.chat;
 
+import static codesquard.app.domain.chat.QChatRoom.*;
+
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+
 public interface ChatRoomRepository extends JpaRepository<ChatRoom, Long> {
+
+	default BooleanExpression equalItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+
+		return chatRoom.item.id.eq(itemId);
+	}
 
 	int deleteByItemId(Long itemId);
 

--- a/backend/src/main/java/codesquard/app/domain/image/ImageFile.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageFile.java
@@ -13,7 +13,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
 import org.springframework.web.multipart.MultipartFile;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ImageErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.ServerInternalException;
 import lombok.Getter;
@@ -77,7 +77,7 @@ public class ImageFile {
 		try {
 			return multipartFile.getInputStream();
 		} catch (IOException e) {
-			throw new ServerInternalException(ErrorCode.FILE_IO_EXCEPTION);
+			throw new ServerInternalException(ImageErrorCode.FILE_IO_EXCEPTION);
 		}
 	}
 
@@ -100,7 +100,7 @@ public class ImageFile {
 					return imageContentType.getContentType();
 				}
 			}
-			throw new BadRequestException(ErrorCode.INVALID_FILE_EXTENSION);
+			throw new BadRequestException(ImageErrorCode.INVALID_FILE_EXTENSION);
 		}
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/image/ImageRepository.java
@@ -29,5 +29,5 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 		@Param("imageUrl") String imageUrl,
 		@Param("thumbnail") boolean thumbnail);
 
-	int deleteByItemId(Long itemId);
+	void deleteByItemId(Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/item/Item.java
+++ b/backend/src/main/java/codesquard/app/domain/item/Item.java
@@ -124,9 +124,14 @@ public class Item {
 		return member.getId() == memberId;
 	}
 
+	public void increaseChatCount() {
+		this.chatCount++;
+	}
+
 	@Override
 	public String toString() {
 		return String.format("%s, %s(id=%d, title=%s, price=%d, status=%s, region=%s, viewCount=%d)",
 			"상품", this.getClass().getSimpleName(), id, title, price, status, region, viewCount);
 	}
+
 }

--- a/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemPaginationRepository.java
@@ -8,9 +8,11 @@ import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import codesquard.app.api.item.response.ItemResponse;
+import codesquard.app.domain.sales.SalesStatus;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -33,13 +35,53 @@ public class ItemPaginationRepository {
 				item.chatCount,
 				item.member.loginId.as("sellerId")))
 			.from(item)
-			.where(itemRepository.lessThanItemId(itemId),
-				itemRepository.equalCategoryId(categoryId),
-				itemRepository.equalTradingRegion(region)
+			.where(lessThanItemId(itemId),
+				equalCategoryId(categoryId),
+				equalTradingRegion(region)
 			)
 			.orderBy(item.createdAt.desc())
 			.limit(size + 1)
 			.fetch();
 		return itemRepository.checkLastPage(size, itemResponses);
 	}
+
+	public BooleanExpression lessThanItemId(Long itemId) {
+		if (itemId == null) {
+			return null;
+		}
+
+		return item.id.lt(itemId);
+	}
+
+	public BooleanExpression equalCategoryId(Long categoryId) {
+		if (categoryId == null) {
+			return null;
+		}
+		return item.category.id.eq(categoryId);
+	}
+
+	public BooleanExpression equalMemberId(Long memberId) {
+		if (memberId == null) {
+			return item.member.id.eq(-1L);
+		}
+		return item.member.id.eq(memberId);
+	}
+
+	public BooleanExpression equalTradingRegion(String region) {
+		if (region == null) {
+			return null;
+		}
+
+		return item.region.like(region + "%");
+	}
+
+	public BooleanExpression equalsStatus(SalesStatus status) {
+		if (status == SalesStatus.ON_SALE) {
+			return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED);
+		} else if (status == SalesStatus.SOLD_OUT) {
+			return item.status.eq(ItemStatus.SOLD_OUT);
+		}
+		return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED, ItemStatus.SOLD_OUT);
+	}
+
 }

--- a/backend/src/main/java/codesquard/app/domain/item/ItemRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemRepository.java
@@ -1,7 +1,5 @@
 package codesquard.app.domain.item;
 
-import static codesquard.app.domain.item.QItem.*;
-
 import java.util.List;
 import java.util.Optional;
 
@@ -12,51 +10,9 @@ import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-
 import codesquard.app.api.item.response.ItemResponse;
-import codesquard.app.domain.sales.SalesStatus;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
-
-	default BooleanExpression lessThanItemId(Long itemId) {
-		if (itemId == null) {
-			return null;
-		}
-
-		return item.id.lt(itemId);
-	}
-
-	default BooleanExpression equalCategoryId(Long categoryId) {
-		if (categoryId == null) {
-			return null;
-		}
-		return item.category.id.eq(categoryId);
-	}
-
-	default BooleanExpression equalMemberId(Long memberId) {
-		if (memberId == null) {
-			return item.member.id.eq(-1L);
-		}
-		return item.member.id.eq(memberId);
-	}
-
-	default BooleanExpression equalTradingRegion(String region) {
-		if (region == null) {
-			return null;
-		}
-
-		return item.region.like(region + "%");
-	}
-
-	default BooleanExpression equalsStatus(SalesStatus status) {
-		if (status == SalesStatus.ON_SALE) {
-			return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED);
-		} else if (status == SalesStatus.SOLD_OUT) {
-			return item.status.eq(ItemStatus.SOLD_OUT);
-		}
-		return item.status.in(ItemStatus.ON_SALE, ItemStatus.RESERVED, ItemStatus.SOLD_OUT);
-	}
 
 	default SliceImpl<ItemResponse> checkLastPage(int size, List<ItemResponse> results) {
 

--- a/backend/src/main/java/codesquard/app/domain/item/ItemStatus.java
+++ b/backend/src/main/java/codesquard/app/domain/item/ItemStatus.java
@@ -5,7 +5,7 @@ import java.util.Arrays;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +25,6 @@ public enum ItemStatus {
 	public static ItemStatus of(String status) {
 		return Arrays.stream(ItemStatus.values())
 			.filter(itemStatus -> itemStatus.getStatus().equals(status))
-			.findFirst().orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_STATUS));
+			.findFirst().orElseThrow(() -> new BadRequestException(ItemErrorCode.INVALID_STATUS));
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/jwt/JwtProvider.java
+++ b/backend/src/main/java/codesquard/app/domain/jwt/JwtProvider.java
@@ -7,7 +7,7 @@ import java.util.Map;
 
 import org.springframework.stereotype.Component;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.ForBiddenException;
 import codesquard.app.domain.member.Member;
@@ -66,9 +66,9 @@ public class JwtProvider {
 				.parseClaimsJws(token)
 				.getBody();
 		} catch (ExpiredJwtException e) {
-			throw new ForBiddenException(ErrorCode.EXPIRE_TOKEN);
+			throw new ForBiddenException(JwtErrorCode.EXPIRE_TOKEN);
 		} catch (JwtException e) {
-			throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+			throw new BadRequestException(JwtErrorCode.INVALID_TOKEN);
 		}
 	}
 
@@ -80,10 +80,10 @@ public class JwtProvider {
 				.parseClaimsJws(token);
 		} catch (ExpiredJwtException e) {
 			log.error("토큰 만료 에러 : {}", e.getMessage());
-			throw new ForBiddenException(ErrorCode.EXPIRE_TOKEN);
+			throw new ForBiddenException(JwtErrorCode.EXPIRE_TOKEN);
 		} catch (JwtException e) {
 			log.error("Jwt 에러 : {}", e.getMessage());
-			throw new BadRequestException(ErrorCode.INVALID_TOKEN);
+			throw new BadRequestException(JwtErrorCode.INVALID_TOKEN);
 		}
 	}
 

--- a/backend/src/main/java/codesquard/app/domain/member/MemberRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/member/MemberRepository.java
@@ -10,9 +10,9 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
 	Optional<Member> findMemberByLoginIdAndEmail(String loginId, String email);
 
-	boolean existsMemberByLoginId(String loginId);
-
 	Optional<Member> findMemberByEmail(String email);
+
+	boolean existsMemberByLoginId(String loginId);
 
 	boolean existsMemberByEmail(String email);
 }

--- a/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/membertown/MemberTownRepository.java
@@ -16,7 +16,10 @@ public interface MemberTownRepository extends JpaRepository<MemberTown, Long> {
 
 	Optional<MemberTown> findMemberTownByMemberIdAndName(Long memberId, String name);
 
-	void deleteMemberTownByMemberIdAndRegionId(Long memberId, Long regionId);
+	@Query("select memberTown.region.id from MemberTown memberTown where memberTown.member.id = :memberId and memberTown.isSelected = :isSelected")
+	Long findRegionIdByMemberIdAndIsSelected(
+		@Param("memberId") Long memberId,
+		@Param("isSelected") boolean isSelected);
 
 	@Modifying
 	@Query("update MemberTown memberTown set memberTown.isSelected = :isSelected where memberTown.region.id = :regionId and memberTown.member.id = :memberId")
@@ -25,8 +28,5 @@ public interface MemberTownRepository extends JpaRepository<MemberTown, Long> {
 		@Param("regionId") Long regionId,
 		@Param("memberId") Long memberId);
 
-	@Query("select memberTown.region.id from MemberTown memberTown where memberTown.member.id = :memberId and memberTown.isSelected = :isSelected")
-	Long findRegionIdByMemberIdAndIsSelected(
-		@Param("memberId") Long memberId,
-		@Param("isSelected") boolean isSelected);
+	void deleteMemberTownByMemberIdAndRegionId(Long memberId, Long regionId);
 }

--- a/backend/src/main/java/codesquard/app/domain/oauth/client/KakaoOauthClient.java
+++ b/backend/src/main/java/codesquard/app/domain/oauth/client/KakaoOauthClient.java
@@ -10,7 +10,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.oauth.response.OauthAccessTokenResponse;
 import codesquard.app.api.oauth.response.OauthUserProfileResponse;
@@ -57,7 +57,7 @@ public class KakaoOauthClient extends OauthClient {
 		log.info("response : {}", response);
 
 		if (Objects.requireNonNull(response).getAccessToken() == null) {
-			throw new BadRequestException(ErrorCode.WRONG_AUTHORIZATION_CODE);
+			throw new BadRequestException(OauthErrorCode.WRONG_AUTHORIZATION_CODE);
 		}
 
 		return response;

--- a/backend/src/main/java/codesquard/app/domain/oauth/client/KakaoOauthClient.java
+++ b/backend/src/main/java/codesquard/app/domain/oauth/client/KakaoOauthClient.java
@@ -12,6 +12,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 
 import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
+import codesquard.app.api.errors.exception.OauthException;
 import codesquard.app.api.oauth.response.OauthAccessTokenResponse;
 import codesquard.app.api.oauth.response.OauthUserProfileResponse;
 import codesquard.app.domain.oauth.properties.OauthProperties;
@@ -47,9 +48,9 @@ public class KakaoOauthClient extends OauthClient {
 			.exchangeToMono(clientResponse -> {
 				log.info("statusCode : {}", clientResponse.statusCode());
 				if (clientResponse.statusCode().is4xxClientError() || clientResponse.statusCode().is5xxServerError()) {
-					return clientResponse.bodyToMono(String.class).handle((s, sink) -> {
-						log.info("s : {}", s);
-						sink.error(new IllegalStateException("error"));
+					return clientResponse.bodyToMono(String.class).handle((body, sink) -> {
+						log.info("responseBody : {}", body);
+						sink.error(new OauthException(OauthErrorCode.FAIL_ACCESS_TOKEN));
 					});
 				}
 				return clientResponse.bodyToMono(OauthAccessTokenResponse.class);

--- a/backend/src/main/java/codesquard/app/domain/oauth/client/NaverOauthClient.java
+++ b/backend/src/main/java/codesquard/app/domain/oauth/client/NaverOauthClient.java
@@ -10,7 +10,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.reactive.function.client.WebClient;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.oauth.response.OauthAccessTokenResponse;
 import codesquard.app.api.oauth.response.OauthUserProfileResponse;
@@ -48,7 +48,7 @@ public class NaverOauthClient extends OauthClient {
 			.block();
 
 		if (Objects.requireNonNull(response).getAccessToken() == null) {
-			throw new BadRequestException(ErrorCode.WRONG_AUTHORIZATION_CODE);
+			throw new BadRequestException(OauthErrorCode.WRONG_AUTHORIZATION_CODE);
 		}
 
 		return response;

--- a/backend/src/main/java/codesquard/app/domain/oauth/repository/InMemoryOauthClientRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/oauth/repository/InMemoryOauthClientRepository.java
@@ -2,7 +2,7 @@ package codesquard.app.domain.oauth.repository;
 
 import java.util.Map;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.domain.oauth.client.OauthClient;
 import lombok.RequiredArgsConstructor;
@@ -16,7 +16,7 @@ public class InMemoryOauthClientRepository implements OauthClientRepository {
 	public OauthClient findOneBy(String providerName) {
 		OauthClient oauthClient = oauthClientMap.get(providerName);
 		if (oauthClient == null) {
-			throw new NotFoundResourceException(ErrorCode.NOT_FOUND_PROVIDER);
+			throw new NotFoundResourceException(OauthErrorCode.NOT_FOUND_PROVIDER);
 		}
 		return oauthClient;
 	}

--- a/backend/src/main/java/codesquard/app/domain/oauth/support/Principal.java
+++ b/backend/src/main/java/codesquard/app/domain/oauth/support/Principal.java
@@ -59,12 +59,6 @@ public class Principal {
 		return memberId.equals(member.getId());
 	}
 
-	@Override
-	public String toString() {
-		return String.format("%s, %s(id=%d, email=%s, loginId=%s)", "Principal", this.getClass().getSimpleName(),
-			memberId, email, loginId);
-	}
-
 	public String createItemViewKey(String key) {
 		return loginId + "-" + key;
 	}
@@ -75,4 +69,11 @@ public class Principal {
 		}
 		return item.getMember().getLoginId();
 	}
+
+	@Override
+	public String toString() {
+		return String.format("%s, %s(id=%d, email=%s, loginId=%s)", "Principal", this.getClass().getSimpleName(),
+			memberId, email, loginId);
+	}
+
 }

--- a/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/sales/SalesPaginationRepository.java
@@ -11,6 +11,7 @@ import com.querydsl.core.types.Projections;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
 import codesquard.app.api.item.response.ItemResponse;
+import codesquard.app.domain.item.ItemPaginationRepository;
 import codesquard.app.domain.item.ItemRepository;
 import codesquard.app.domain.oauth.support.Principal;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class SalesPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
 	private final ItemRepository itemRepository;
+	private final ItemPaginationRepository itemPaginationRepository;
 
 	public Slice<ItemResponse> findAll(SalesStatus status, int size, Long cursor, Principal principal) {
 		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
@@ -36,9 +38,9 @@ public class SalesPaginationRepository {
 				item.member.loginId.as("sellerId")))
 			.from(item)
 			.where(
-				itemRepository.equalMemberId(principal.getMemberId()),
-				itemRepository.lessThanItemId(cursor),
-				itemRepository.equalsStatus(status))
+				itemPaginationRepository.equalMemberId(principal.getMemberId()),
+				itemPaginationRepository.lessThanItemId(cursor),
+				itemPaginationRepository.equalsStatus(status))
 			.orderBy(item.createdAt.desc())
 			.limit(size + 1)
 			.fetch();

--- a/backend/src/main/java/codesquard/app/domain/sales/SalesStatus.java
+++ b/backend/src/main/java/codesquard/app/domain/sales/SalesStatus.java
@@ -2,7 +2,7 @@ package codesquard.app.domain.sales;
 
 import java.util.Arrays;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.SalesErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +20,6 @@ public enum SalesStatus {
 		return Arrays.stream(SalesStatus.values())
 			.filter(salesStatus -> salesStatus.getStatus().equals(stringStatus.toLowerCase()))
 			.findFirst()
-			.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER));
+			.orElseThrow(() -> new BadRequestException(SalesErrorCode.INVALID_SALES_PARAMETER));
 	}
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishPaginationRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishPaginationRepository.java
@@ -21,8 +21,9 @@ public class WishPaginationRepository {
 
 	private final JPAQueryFactory queryFactory;
 	private final ItemRepository itemRepository;
+	private final WishRepository wishRepository;
 
-	public Slice<ItemResponse> findAll(Long categoryId, int size, Long cursor) {
+	public Slice<ItemResponse> findAll(Long categoryId, int size, Long cursor, Long memberId) {
 		List<ItemResponse> itemResponses = queryFactory.select(Projections.fields(ItemResponse.class,
 				item.id.as("itemId"),
 				item.thumbnailUrl,
@@ -38,7 +39,8 @@ public class WishPaginationRepository {
 			.join(wish.item, item)
 			.on(wish.item.id.eq(item.id))
 			.where(itemRepository.lessThanItemId(cursor),
-				itemRepository.equalCategoryId(categoryId))
+				itemRepository.equalCategoryId(categoryId),
+				wishRepository.equalMemberId(memberId))
 			.orderBy(wish.createdAt.desc())
 			.limit(size + 1)
 			.fetch();

--- a/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
@@ -5,12 +5,21 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import com.querydsl.core.types.dsl.BooleanExpression;
+
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
+
+	default BooleanExpression equalMemberId(Long memberId) {
+		if (memberId == null) {
+			return null;
+		}
+		return QWish.wish.member.id.eq(memberId);
+	}
 
 	void deleteByItemId(Long itemId);
 
 	boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
-	
+
 	List<Wish> findAllByMemberId(Long memberId);
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishRepository.java
@@ -5,21 +5,14 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
-import com.querydsl.core.types.dsl.BooleanExpression;
-
 @Repository
 public interface WishRepository extends JpaRepository<Wish, Long> {
 
-	default BooleanExpression equalMemberId(Long memberId) {
-		if (memberId == null) {
-			return null;
-		}
-		return QWish.wish.member.id.eq(memberId);
-	}
-
-	void deleteByItemId(Long itemId);
+	void deleteAllByIdIn(List<Long> wishIds);
 
 	boolean existsByMemberIdAndItemId(Long memberId, Long itemId);
 
 	List<Wish> findAllByMemberId(Long memberId);
+
+	List<Wish> findByItemId(Long itemId);
 }

--- a/backend/src/main/java/codesquard/app/domain/wish/WishStatus.java
+++ b/backend/src/main/java/codesquard/app/domain/wish/WishStatus.java
@@ -2,7 +2,7 @@ package codesquard.app.domain.wish;
 
 import java.util.Arrays;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.SalesErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +20,6 @@ public enum WishStatus {
 		return Arrays.stream(WishStatus.values())
 			.filter(wishStatus -> wishStatus.getStatus().equals(stringStatus.toLowerCase()))
 			.findFirst()
-			.orElseThrow(() -> new BadRequestException(ErrorCode.INVALID_PARAMETER));
+			.orElseThrow(() -> new BadRequestException(SalesErrorCode.INVALID_SALES_PARAMETER));
 	}
 }

--- a/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/JwtAuthorizationFilter.java
@@ -18,6 +18,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtErrorCode;
 import codesquard.app.api.errors.exception.SecondHandException;
 import codesquard.app.api.errors.exception.UnAuthorizationException;
 import codesquard.app.api.redis.OauthRedisService;
@@ -67,7 +68,8 @@ public class JwtAuthorizationFilter extends OncePerRequestFilter {
 			return;
 		}
 		try {
-			String token = extractJwt(request).orElseThrow(() -> new UnAuthorizationException(ErrorCode.EMPTY_TOKEN));
+			String token = extractJwt(request).orElseThrow(
+				() -> new UnAuthorizationException(JwtErrorCode.EMPTY_TOKEN));
 			jwtProvider.validateToken(token);
 			redisService.validateAlreadyLogout(token);
 			authenticationContext.setPrincipal(jwtProvider.extractPrincipal(token));

--- a/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
+++ b/backend/src/main/java/codesquard/app/filter/LogoutFilter.java
@@ -19,6 +19,7 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtErrorCode;
 import codesquard.app.api.errors.exception.SecondHandException;
 import codesquard.app.api.errors.exception.UnAuthorizationException;
 import codesquard.app.api.redis.OauthRedisService;
@@ -51,7 +52,8 @@ public class LogoutFilter extends OncePerRequestFilter {
 			return;
 		}
 		try {
-			String token = extractJwt(request).orElseThrow(() -> new UnAuthorizationException(ErrorCode.EMPTY_TOKEN));
+			String token = extractJwt(request).orElseThrow(
+				() -> new UnAuthorizationException(JwtErrorCode.EMPTY_TOKEN));
 			redisService.validateAlreadyLogout(token);
 		} catch (SecondHandException e) {
 			setErrorResponse(response, e.getErrorCode());

--- a/backend/src/main/java/codesquard/app/interceptor/CacheInterceptor.java
+++ b/backend/src/main/java/codesquard/app/interceptor/CacheInterceptor.java
@@ -1,5 +1,0 @@
-package codesquard.app.interceptor;
-
-public class CacheInterceptor {
-
-}

--- a/backend/src/main/java/codesquard/app/interceptor/LogoutInterceptor.java
+++ b/backend/src/main/java/codesquard/app/interceptor/LogoutInterceptor.java
@@ -10,7 +10,7 @@ import javax.servlet.http.HttpServletResponse;
 import org.springframework.util.StringUtils;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.JwtErrorCode;
 import codesquard.app.api.errors.exception.UnAuthorizationException;
 import lombok.extern.slf4j.Slf4j;
 
@@ -20,7 +20,8 @@ public class LogoutInterceptor implements HandlerInterceptor {
 	public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws
 		Exception {
 		log.debug("로그인 인터셉터 접속 : {}", request.getRequestURI());
-		String accessToken = extractJwt(request).orElseThrow(() -> new UnAuthorizationException(ErrorCode.EMPTY_TOKEN));
+		String accessToken = extractJwt(request).orElseThrow(
+			() -> new UnAuthorizationException(JwtErrorCode.EMPTY_TOKEN));
 		request.setAttribute("accessToken", accessToken);
 		return true;
 	}

--- a/backend/src/test/java/codesquard/app/CategoryTestSupport.java
+++ b/backend/src/test/java/codesquard/app/CategoryTestSupport.java
@@ -3,7 +3,7 @@ package codesquard.app;
 import java.util.ArrayList;
 import java.util.List;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.CategoryErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.domain.category.Category;
 
@@ -42,6 +42,6 @@ public class CategoryTestSupport {
 		return categories.stream()
 			.filter(category -> category.getName().equals(name))
 			.findAny()
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_CATEGORY));
+			.orElseThrow(() -> new NotFoundResourceException(CategoryErrorCode.NOT_FOUND_CATEGORY));
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/category/CategoryQueryServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/category/CategoryQueryServiceTest.java
@@ -30,7 +30,7 @@ class CategoryQueryServiceTest {
 
 	@DisplayName("모든 카테고리 목록을 조회한다")
 	@Test
-	public void findAll() {
+	void findAll() {
 		// given
 		categoryRepository.saveAll(getCategories());
 

--- a/backend/src/test/java/codesquard/app/api/category/CategoryRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/category/CategoryRestControllerTest.java
@@ -33,7 +33,7 @@ class CategoryRestControllerTest extends ControllerTestSupport {
 	private CategoryRestController categoryRestController;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(categoryRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
@@ -43,7 +43,7 @@ class CategoryRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("카테고리 목록을 조회한다")
 	@Test
-	public void findAll() throws Exception {
+	void findAll() throws Exception {
 		// given
 		CategoryListResponse response = new CategoryListResponse(getCategories());
 		given(categoryQueryService.findAll()).willReturn(response);

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
@@ -14,6 +14,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -190,7 +191,8 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 		// then
 		mockMvc.perform(asyncDispatch(asyncListener))
 			.andExpect(status().isOk())
-			.andExpect(jsonPath("statusCode").value(equalTo(408)))
-			.andExpect(jsonPath("message").value(equalTo("새로운 채팅 메시지가 존재하지 않습니다.")));
+			.andExpect(jsonPath("statusCode").value(equalTo(200)))
+			.andExpect(jsonPath("message").value(equalTo("새로운 채팅 메시지가 존재하지 않습니다.")))
+			.andExpect(jsonPath("data").value(equalTo(Collections.emptyList())));
 	}
 }

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
@@ -28,7 +28,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockAsyncContext;
@@ -142,7 +141,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 		ChatLogMessageResponse messageResponse = ChatLogMessageResponse.from(chatLog, Principal.from(buyer));
 		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(messageResponse),
 			null);
-		given(chatLogService.readMessages(anyLong(), any(Principal.class), anyLong(), any(Pageable.class)))
+		given(chatLogService.readMessages(anyLong(), any(Principal.class), anyLong()))
 			.willReturn(response);
 		int chatRoomId = 1;
 
@@ -173,8 +172,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 		given(chatLogService.readMessages(
 			anyLong(),
 			any(Principal.class),
-			anyLong(),
-			any(Pageable.class)
+			anyLong()
 		)).willReturn(response);
 		int chatRoomId = 1;
 

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
@@ -140,7 +140,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 		ChatLog chatLog = new ChatLog("안녕하세요. 롤러블레이브를 사고 싶습니다. 만원만 깍아주세요.", "23Yong", "carlynne", chatRoom, 1);
 		ChatLogMessageResponse messageResponse = ChatLogMessageResponse.from(chatLog, Principal.from(buyer));
 		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(messageResponse),
-			false, null);
+			null);
 		given(chatLogService.readMessages(anyLong(), any(Principal.class), anyLong(), any(Pageable.class)))
 			.willReturn(response);
 		int chatRoomId = 1;
@@ -168,7 +168,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 	public void readMessagesWithTimeout() throws Exception {
 		// given
 		ChatLogItemResponse itemResponse = null;
-		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(), false, null);
+		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(), null);
 		given(chatLogService.readMessages(
 			anyLong(),
 			any(Principal.class),

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogRestControllerTest.java
@@ -72,7 +72,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 	private PageableHandlerMethodArgumentResolver pageableHandlerMethodArgumentResolver;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(chatLogRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(pageableHandlerMethodArgumentResolver, authPrincipalArgumentResolver)
@@ -87,7 +87,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("구매자가 판매자에게 채팅 메시지를 전송합니다.")
 	@Test
-	public void sendMessage() throws Exception {
+	void sendMessage() throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("message", "롤러 블레이드 삽니다.");
@@ -127,7 +127,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원은 채팅방 안에 채팅 메시지 목록들을 요청합니다.")
 	@Test
-	public void readMessages() throws Exception {
+	void readMessages() throws Exception {
 		// given
 		Member seller = createMember("avatarUrl", "carlynne@naver.com", "carlynne");
 		Member buyer = createMember("avatarUrl", "23Yong@gmail.com", "23Yong");
@@ -165,7 +165,7 @@ class ChatLogRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원이 새로운 채팅 메시지를 요청했지만 새로운 메시지가 없다는 응답을 받는다")
 	@Test
-	public void readMessagesWithTimeout() throws Exception {
+	void readMessagesWithTimeout() throws Exception {
 		// given
 		ChatLogItemResponse itemResponse = null;
 		ChatLogListResponse response = new ChatLogListResponse("carlynne", itemResponse, List.of(), null);

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
@@ -92,7 +92,7 @@ class ChatLogServiceTest {
 
 	@DisplayName("채팅 메시지를 전송한다")
 	@Test
-	public void sendMessage() throws JsonProcessingException {
+	void sendMessage() throws JsonProcessingException {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
 		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));
@@ -132,7 +132,7 @@ class ChatLogServiceTest {
 
 	@DisplayName("판매자가 구매자의 채팅 로그들을 읽는다")
 	@Test
-	public void readMessage() {
+	void readMessage() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
 		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
@@ -27,7 +27,6 @@ import codesquard.app.RegionTestSupport;
 import codesquard.app.api.chat.request.ChatLogSendRequest;
 import codesquard.app.api.chat.response.ChatLogListResponse;
 import codesquard.app.api.chat.response.ChatLogSendResponse;
-import codesquard.app.api.errors.exception.ForBiddenException;
 import codesquard.app.domain.category.Category;
 import codesquard.app.domain.category.CategoryRepository;
 import codesquard.app.domain.chat.ChatLog;
@@ -173,49 +172,4 @@ class ChatLogServiceTest {
 				count -> count == 0)
 		);
 	}
-
-	@DisplayName("구매자와 판매자가 아닌 제 3자가 채팅방의 채팅 메시지를 읽을 수 없다.")
-	@Test
-	public void readMessageWithOtherMember() {
-		// given
-		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
-		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));
-		Member anonymous = memberRepository.save(createMember("avatarUrlValue3", "lee1234@gmail.com", "lee1234"));
-
-		Region region = regionRepository.save(RegionTestSupport.createRegion("서울 종로구 청운동"));
-
-		memberTownRepository.saveAll(List.of(
-			createMemberTown(seller, region, true),
-			createMemberTown(buyer, region, true)));
-
-		Category sport = categoryRepository.save(findByName("스포츠/레저"));
-		Item item = createItem("빈티지 롤러 블레이드", "어린시절 추억의향수를 불러 일으키는 롤러 스케이트입니다.", 200000L, ON_SALE,
-			"가락동", "thumbnailUrl", seller, sport);
-
-		Item saveItem = itemRepository.save(item);
-		List<Image> images = List.of(
-			new Image("imageUrlValue1", saveItem, true),
-			new Image("imageUrlValue2", saveItem, false));
-		imageRepository.saveAll(images);
-
-		ChatRoom chatRoom = chatRoomRepository.save(new ChatRoom(buyer, item));
-
-		chatLogRepository.saveAll(List.of(
-			ChatLog.createBySender("롤러 블레이드 사고 싶음", chatRoom, Principal.from(buyer)),
-			ChatLog.createBySender("깍아주세요.", chatRoom, Principal.from(buyer))
-		));
-
-		Long cursor = null;
-
-		// when
-		Throwable throwable = catchThrowable(
-			() -> chatLogService.readMessages(chatRoom.getId(), Principal.from(anonymous), cursor));
-
-		// then
-		assertThat(throwable)
-			.isInstanceOf(ForBiddenException.class)
-			.extracting("errorCode.message")
-			.isEqualTo("채팅에 대한 권한이 없습니다.");
-	}
-
 }

--- a/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatLogServiceTest.java
@@ -17,7 +17,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -163,11 +162,9 @@ class ChatLogServiceTest {
 		));
 
 		Long cursor = null;
-		Pageable pageable = Pageable.ofSize(10);
 
 		// when
-		ChatLogListResponse response = chatLogService.readMessages(chatRoom.getId(), Principal.from(seller), cursor,
-			pageable);
+		ChatLogListResponse response = chatLogService.readMessages(chatRoom.getId(), Principal.from(seller), cursor);
 
 		// then
 		assertAll(
@@ -209,12 +206,10 @@ class ChatLogServiceTest {
 		));
 
 		Long cursor = null;
-		Pageable pageable = Pageable.ofSize(10);
 
 		// when
 		Throwable throwable = catchThrowable(
-			() -> chatLogService.readMessages(chatRoom.getId(), Principal.from(anonymous), cursor,
-				pageable));
+			() -> chatLogService.readMessages(chatRoom.getId(), Principal.from(anonymous), cursor));
 
 		// then
 		assertThat(throwable)

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
@@ -9,7 +9,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.request;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 import java.util.HashMap;
@@ -27,7 +26,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import codesquard.app.ControllerTestSupport;
@@ -78,7 +76,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 	public void createChatRoom() throws Exception {
 		// given
 		Map<String, Object> responseBody = new HashMap<>();
-		responseBody.put("id", 1L);
+		responseBody.put("chatRoomId", 1L);
 
 		ChatRoomCreateResponse response = objectMapper.readValue(objectMapper.writeValueAsString(responseBody),
 			ChatRoomCreateResponse.class);
@@ -93,7 +91,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 			.andExpect(status().isCreated())
 			.andExpect(jsonPath("statusCode").value(equalTo(201)))
 			.andExpect(jsonPath("message").value(equalTo("채팅방 생성을 완료하였습니다.")))
-			.andExpect(jsonPath("data.id").value(equalTo(1)));
+			.andExpect(jsonPath("data.chatRoomId").value(equalTo(1)));
 	}
 
 	@DisplayName("회원은 채팅방 목록을 요청한다")
@@ -120,11 +118,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 			.willReturn(response);
 
 		// when & then
-		MvcResult asyncListener = mockMvc.perform(get("/api/chats"))
-			.andExpect(request().asyncStarted())
-			.andReturn();
-
-		mockMvc.perform(asyncDispatch(asyncListener))
+		mockMvc.perform(get("/api/chats"))
 			.andExpect(status().isOk())
 			.andExpect(jsonPath("statusCode").value(equalTo(200)))
 			.andExpect(jsonPath("message").value(equalTo("채팅방 목록 조회를 완료하였습니다.")))

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomRestControllerTest.java
@@ -58,7 +58,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 	private PageableHandlerMethodArgumentResolver pageableHandlerMethodArgumentResolver;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(chatRoomRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(pageableHandlerMethodArgumentResolver, authPrincipalArgumentResolver)
@@ -73,7 +73,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("채팅방 생성을 요청한다")
 	@Test
-	public void createChatRoom() throws Exception {
+	void createChatRoom() throws Exception {
 		// given
 		Map<String, Object> responseBody = new HashMap<>();
 		responseBody.put("chatRoomId", 1L);
@@ -96,7 +96,7 @@ class ChatRoomRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원은 채팅방 목록을 요청한다")
 	@Test
-	public void readAllChatRoom() throws Exception {
+	void readAllChatRoom() throws Exception {
 		// given
 		Member seller = createMember("avatarUrl", "carlynne@naver.com", "carlynne");
 		Member buyer = createMember("avatarUrlValue", "carlynne@naver.com", "carlynne");

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
@@ -117,7 +117,7 @@ class ChatRoomServiceTest {
 		// then
 		assertAll(() -> {
 			assertThat(response)
-				.extracting("id")
+				.extracting("chatRoomId")
 				.isNotNull();
 		});
 	}

--- a/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/chat/ChatRoomServiceTest.java
@@ -90,7 +90,7 @@ class ChatRoomServiceTest {
 
 	@DisplayName("구매자가 한 상품에 대한 채팅방을 생성한다")
 	@Test
-	public void createChatRoom() {
+	void createChatRoom() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
 		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));
@@ -124,7 +124,7 @@ class ChatRoomServiceTest {
 
 	@DisplayName("판매자 회원이 채팅방 목록을 조회한다.")
 	@Test
-	public void readAllChatRoomWithSeller() {
+	void readAllChatRoomWithSeller() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
 		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));
@@ -171,7 +171,7 @@ class ChatRoomServiceTest {
 
 	@DisplayName("구매자 회원이 채팅방 목록을 조회한다.")
 	@Test
-	public void readAllChatRoomWithBuyer() {
+	void readAllChatRoomWithBuyer() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue1", "23Yong@gmail.com", "23Yong"));
 		Member buyer = memberRepository.save(createMember("avatarUrlValue2", "bruni@gmail.com", "bruni"));

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import codesquard.app.ControllerTestSupport;
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.ItemErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.item.response.ItemDetailResponse;
 import codesquard.app.domain.category.Category;
@@ -71,7 +71,7 @@ class ItemControllerTest extends ControllerTestSupport {
 
 		ItemDetailResponse response = ItemDetailResponse.toBuyer(item, seller.getId(), imageUrls, false, null);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
-		
+
 		// when & then
 		mockMvc.perform(get("/api/items/1"))
 			.andExpect(status().isOk())
@@ -130,7 +130,7 @@ class ItemControllerTest extends ControllerTestSupport {
 	public void findDetailItemWithNotExistItem() throws Exception {
 		// given
 		given(itemService.findDetailItemBy(any(), any()))
-			.willThrow(new NotFoundResourceException(ErrorCode.ITEM_NOT_FOUND));
+			.willThrow(new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
 
 		// when & then
 		mockMvc.perform(get("/api/items/9999"))

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -46,7 +46,7 @@ class ItemControllerTest extends ControllerTestSupport {
 	private ItemService itemService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(itemController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
@@ -61,7 +61,7 @@ class ItemControllerTest extends ControllerTestSupport {
 
 	@DisplayName("판매자가 자신이 판매하는 상품의 상세한 내용을 조회합니다.")
 	@Test
-	public void findDetailItemBySeller() throws Exception {
+	void findDetailItemBySeller() throws Exception {
 		// given
 		Member seller = createMember("avatarUrl", "23Yong@gmail.com", "23Yong");
 		Category sport = findByName("스포츠/레저");
@@ -94,7 +94,7 @@ class ItemControllerTest extends ControllerTestSupport {
 
 	@DisplayName("구매자가 상품의 상세한 내용을 조회합니다.")
 	@Test
-	public void findDetailItemByBuyer() throws Exception {
+	void findDetailItemByBuyer() throws Exception {
 		// given
 		Member seller = createMember("avatarUrl", "23Yong@gmail.com", "23Yong");
 		Category sport = findByName("스포츠/레저");
@@ -127,7 +127,7 @@ class ItemControllerTest extends ControllerTestSupport {
 
 	@DisplayName("구매자가 상품의 상세한 내용을 조회합니다.")
 	@Test
-	public void findDetailItemWithNotExistItem() throws Exception {
+	void findDetailItemWithNotExistItem() throws Exception {
 		// given
 		given(itemService.findDetailItemBy(any(), any()))
 			.willThrow(new NotFoundResourceException(ItemErrorCode.ITEM_NOT_FOUND));
@@ -142,7 +142,7 @@ class ItemControllerTest extends ControllerTestSupport {
 
 	@DisplayName("상품을 삭제합니다.")
 	@Test
-	public void deleteItem() throws Exception {
+	void deleteItem() throws Exception {
 		// given
 		willDoNothing().given(itemService).deleteItem(
 			ArgumentMatchers.anyLong(),

--- a/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemControllerTest.java
@@ -69,8 +69,9 @@ class ItemControllerTest extends ControllerTestSupport {
 			"가락동", "thumbnailUrl", seller, sport);
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.toBuyer(item, seller.getId(), imageUrls, false);
+		ItemDetailResponse response = ItemDetailResponse.toBuyer(item, seller.getId(), imageUrls, false, null);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
+		
 		// when & then
 		mockMvc.perform(get("/api/items/1"))
 			.andExpect(status().isOk())
@@ -102,7 +103,7 @@ class ItemControllerTest extends ControllerTestSupport {
 		Long loginMemberId = 9999L;
 		List<String> imageUrls = List.of("imageUrlValue1", "imageUrlValue2");
 
-		ItemDetailResponse response = ItemDetailResponse.toSeller(item, loginMemberId, imageUrls, false, 1L);
+		ItemDetailResponse response = ItemDetailResponse.toSeller(item, loginMemberId, imageUrls, false);
 		given(itemService.findDetailItemBy(any(), any())).willReturn(response);
 		// when & then
 		mockMvc.perform(get("/api/items/1"))

--- a/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/item/ItemServiceTest.java
@@ -173,7 +173,7 @@ class ItemServiceTest {
 
 	@DisplayName("회원은 상품 정보 수정시 기존 썸네일 이미지를 두고 수정한다")
 	@Test
-	public void modifyItem() throws IOException {
+	void modifyItem() throws IOException {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		Region region = regionRepository.save(createRegion("서울 송파구 가락동"));
@@ -239,7 +239,7 @@ class ItemServiceTest {
 
 	@DisplayName("회원은 상품 정보 수정시 새로운 썸네일 이미지를 두고 수정한다")
 	@Test
-	public void modifyItemWithNewThumbnail() throws IOException {
+	void modifyItemWithNewThumbnail() throws IOException {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 
@@ -304,7 +304,7 @@ class ItemServiceTest {
 
 	@DisplayName("회원은 상품 정보 수정시 썸네일 이미지를 그대로 두고 수정한다")
 	@Test
-	public void modifyItemWithNonChange() throws IOException {
+	void modifyItemWithNonChange() throws IOException {
 		// given
 		Category category = categoryRepository.save(findByName("스포츠/레저"));
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
@@ -388,7 +388,7 @@ class ItemServiceTest {
 
 	@DisplayName("판매자가 한 상품의 상세한 정보를 조회한다")
 	@Test
-	public void findDetailItemBySeller() {
+	void findDetailItemBySeller() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		Principal principal = Principal.from(seller);
@@ -423,7 +423,7 @@ class ItemServiceTest {
 
 	@DisplayName("존재하지 않는 상품 등록번호로 상품을 조회할 수 없다")
 	@Test
-	public void findDetailItemWithNotExistItem() {
+	void findDetailItemWithNotExistItem() {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		Principal principal = Principal.from(member);
@@ -440,7 +440,7 @@ class ItemServiceTest {
 
 	@DisplayName("상품을 삭제합니다.")
 	@Test
-	public void deleteItem() {
+	void deleteItem() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(
@@ -474,7 +474,7 @@ class ItemServiceTest {
 
 	@DisplayName("존재하지 않는 상품을 삭제할 수 없다.")
 	@Test
-	public void deleteItemWithNotExistItem() {
+	void deleteItemWithNotExistItem() {
 		// given
 		Member seller = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(
@@ -508,7 +508,7 @@ class ItemServiceTest {
 
 	@DisplayName("판매자가 아닌 사람이 판매자의 상품을 삭제할 수 없다")
 	@Test
-	public void deleteItemWithNotSeller() {
+	void deleteItemWithNotSeller() {
 		// given
 		List<Member> members = memberRepository.saveAll(
 			List.of(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"),

--- a/backend/src/test/java/codesquard/app/api/member/MemberControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/member/MemberControllerTest.java
@@ -46,7 +46,7 @@ class MemberControllerTest extends ControllerTestSupport {
 	private MemberService memberService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(memberController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
@@ -61,7 +61,7 @@ class MemberControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원은 회원의 동네를 조회할 수 있다")
 	@Test
-	public void readALlMemberTowns() throws Exception {
+	void readALlMemberTowns() throws Exception {
 		// given
 		Member member = createMember("avatarUrl", "23Yong@gmail.com", "23Yong");
 		Region region = createRegion("서울 송파구 가락동");

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownRestControllerTest.java
@@ -46,7 +46,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 	private MemberTownService memberTownService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(memberTownRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
@@ -56,7 +56,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("주소 등록번호를 가지고 회원 동네를 추가한다")
 	@Test
-	public void addMemberTown() throws Exception {
+	void addMemberTown() throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("addressId", 1L);
@@ -83,7 +83,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("주소 등록번호를 가지고 회원의 동네를 삭제한다")
 	@Test
-	public void removeMemberTown() throws Exception {
+	void removeMemberTown() throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("addressId", 1L);
@@ -105,7 +105,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("주소 등록번호가 null이면 회원의 동네를 제거할 수 없다")
 	@Test
-	public void removeMemberTownWithAddressIsNull() throws Exception {
+	void removeMemberTownWithAddressIsNull() throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("addressId", null);
@@ -124,7 +124,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원이 지역 등록번호를 가지고 회원의 동네를 선택한다")
 	@Test
-	public void selectRegion() throws Exception {
+	void selectRegion() throws Exception {
 		// given
 		Map<String, Object> requestBody = Map.of("selectedAddressId", 1L);
 
@@ -142,7 +142,7 @@ class MemberTownRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("회원이 지역 등록번호를 null을 전달하여 회원의 동네를 선택할 수 없다")
 	@Test
-	public void selectRegionWithSelectedAddressIdIsNull() throws Exception {
+	void selectRegionWithSelectedAddressIdIsNull() throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("selectedAddressId", null);

--- a/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/membertown/MemberTownServiceTest.java
@@ -64,7 +64,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("선택한 동네를 회원 동네에 추가한다")
 	@Test
-	public void addMemberTown() throws JsonProcessingException {
+	void addMemberTown() throws JsonProcessingException {
 		// given
 		Region region = regionRepository.save(createRegion("서울 송파구 가락동"));
 
@@ -89,7 +89,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("주소에 없는 동네를 회원 동네에 추가할 수 없다")
 	@Test
-	public void addMemberTownWithNotExistFullAddressName() throws JsonProcessingException {
+	void addMemberTownWithNotExistFullAddressName() throws JsonProcessingException {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("addressId", 9999L);
@@ -112,7 +112,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원의 동네 추가시 동네 등록 최대개수를 초과하여서 회원의 동네를 추가할 수 없다")
 	@Test
-	public void addMemberTownWithOverTheMaximumMemberTownSize() throws JsonProcessingException {
+	void addMemberTownWithOverTheMaximumMemberTownSize() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		Member saveMember = memberRepository.save(member);
@@ -141,7 +141,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원의 동네 추가시 이미 등록된 동네는 중복으로 추가할 수 없다")
 	@Test
-	public void addMemberTownWithDuplicateAddressName() throws JsonProcessingException {
+	void addMemberTownWithDuplicateAddressName() throws JsonProcessingException {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		Region region = regionRepository.save(createRegion("서울 종로구 신교동"));
@@ -165,7 +165,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("주소를 가지고 회원의 등록된 동네를 제거한다")
 	@Test
-	public void removeMemberTown() throws JsonProcessingException {
+	void removeMemberTown() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		Member saveMember = memberRepository.save(member);
@@ -201,7 +201,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("등록되지 않은 주소 이름을 가지고 회원의 동네를 제거할 수 없다")
 	@Test
-	public void removeMemberTownWithNotRegisteredAddressName() throws JsonProcessingException {
+	void removeMemberTownWithNotRegisteredAddressName() throws JsonProcessingException {
 		// given
 		Region region = regionRepository.save(createRegion("서울 종로구 효자동"));
 
@@ -229,7 +229,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원의 동네가 1개인 상태에서 회원의 동네를 제거할 수 없다")
 	@Test
-	public void removeMemberTownWithMinimumMemberTownSize() throws JsonProcessingException {
+	void removeMemberTownWithMinimumMemberTownSize() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		Member saveMember = memberRepository.save(member);
@@ -256,7 +256,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원이 자신이 등록한 동네 지역을 선택한다")
 	@Test
-	public void selectRegion() throws JsonProcessingException {
+	void selectRegion() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(
@@ -288,7 +288,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원은 존재하지 않는 지역 등록번호로 동네 지역을 선택할 수 없다")
 	@Test
-	public void selectRegionWithNotExistRegionId() throws JsonProcessingException {
+	void selectRegionWithNotExistRegionId() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(
@@ -313,7 +313,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원은 회원의 동네로 등록되지 않은 동네지역을 선택할 수 없다")
 	@Test
-	public void selectRegionWithNotRegisteredRegionId() throws JsonProcessingException {
+	void selectRegionWithNotRegisteredRegionId() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(
@@ -338,7 +338,7 @@ class MemberTownServiceTest {
 
 	@DisplayName("회원은 자신의 회원 동네를 조회할 수 있다")
 	@Test
-	public void readAll() throws JsonProcessingException {
+	void readAll() throws JsonProcessingException {
 		// given
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 		List<Region> regions = regionRepository.saveAll(List.of(createRegion("서울 송파구 가락동")));

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthRestControllerTest.java
@@ -54,7 +54,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 	private OauthService oauthService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(oauthRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.addFilters(
@@ -69,7 +69,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("프로필 사진, 로그인 아이디, 동네를 전달하여 소셜 로그인 인증을 하고 회원가입을 한다")
 	@Test
-	public void signup() throws Exception {
+	void signup() throws Exception {
 		// given
 		Map<String, Object> responseBody = new HashMap<>();
 		responseBody.put("id", 1L);
@@ -100,7 +100,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 	@DisplayName("입력 형식에 맞지 않는 로그인 아이디를 전달하여 회원가입을 요청할때 에러를 응답한다")
 	@MethodSource(value = "provideInvalidLoginId")
 	@ParameterizedTest
-	public void signupWhenInvalidLoginId(String loginId) throws Exception {
+	void signupWhenInvalidLoginId(String loginId) throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("loginId", loginId);
@@ -126,7 +126,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 	@DisplayName("유효하지 않은 입력 형식의 주소 등록번호를 전달하여 회원가입을 요청할 때 에러를 응답한다")
 	@MethodSource(value = "provideInvalidAddressIds")
 	@ParameterizedTest
-	public void signupWhenInvalidAddrName(List<Long> addressIds) throws Exception {
+	void signupWhenInvalidAddrName(List<Long> addressIds) throws Exception {
 		// given
 		Map<String, Object> requestBody = new HashMap<>();
 		requestBody.put("loginId", "23Yong");
@@ -151,7 +151,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("로그아웃을 요청한다")
 	@Test
-	public void logout() throws Exception {
+	void logout() throws Exception {
 		// given
 		Map<String, String> requestBody = new HashMap<>();
 		requestBody.put("refreshToken", "refreshTokenValue");
@@ -171,7 +171,7 @@ class OauthRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("액세스 토큰 갱신을 요청한다")
 	@Test
-	public void refreshAccessToken() throws Exception {
+	void refreshAccessToken() throws Exception {
 		// given
 		given(authPrincipalArgumentResolver.supportsParameter(any())).willReturn(true);
 

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -28,7 +28,8 @@ import org.springframework.test.context.ActiveProfiles;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.BadRequestException;
 import codesquard.app.api.errors.exception.ConflictException;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
@@ -135,7 +136,7 @@ class OauthServiceTest {
 
 		// then
 		Member findMember = memberRepository.findMemberByLoginId("23Yong")
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 		List<MemberTown> memberTowns = memberTownRepository.findAllByMemberId(findMember.getId());
 
 		assertAll(() -> {
@@ -236,7 +237,7 @@ class OauthServiceTest {
 			OauthSignUpRequest.class);
 
 		given(oauthClientRepository.findOneBy(anyString()))
-			.willThrow(new NotFoundResourceException(ErrorCode.NOT_FOUND_PROVIDER));
+			.willThrow(new NotFoundResourceException(OauthErrorCode.NOT_FOUND_PROVIDER));
 
 		String provider = "github";
 		String code = "1234";
@@ -274,7 +275,7 @@ class OauthServiceTest {
 		given(oauthClient.exchangeAccessTokenByAuthorizationCode(anyString(), anyString()))
 			.willReturn(mockAccessTokenResponse);
 		given(oauthClient.getUserProfileByAccessToken(any(OauthAccessTokenResponse.class)))
-			.willThrow(new BadRequestException(ErrorCode.WRONG_AUTHORIZATION_CODE));
+			.willThrow(new BadRequestException(OauthErrorCode.WRONG_AUTHORIZATION_CODE));
 
 		String provider = "naver";
 		String code = "1234";

--- a/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/OauthServiceTest.java
@@ -98,7 +98,7 @@ class OauthServiceTest {
 
 	@DisplayName("로그인 아이디와 소셜 로그인을 하여 회원가입을 한다")
 	@Test
-	public void signUp() throws IOException {
+	void signUp() throws IOException {
 		// given
 		regionRepository.save(createRegion("서울 송파구 가락동"));
 		List<Long> addressIds = getAddressIds(regionRepository.findAllByNameIn(List.of("서울 송파구 가락동")));
@@ -152,7 +152,7 @@ class OauthServiceTest {
 
 	@DisplayName("중복된 로그인 아이디로 회원가입을 할 수 없다")
 	@Test
-	public void signupWithDuplicateLoginId() throws IOException {
+	void signupWithDuplicateLoginId() throws IOException {
 		// given
 		memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
 
@@ -178,7 +178,7 @@ class OauthServiceTest {
 
 	@DisplayName("한 명의 소셜 사용자가 서로 다른 로그인 아이디로 이중 회원가입을 할 수 없다")
 	@Test
-	public void signupWithMultipleLoginId() throws IOException {
+	void signupWithMultipleLoginId() throws IOException {
 		// given
 		memberRepository.deleteAllInBatch();
 		memberRepository.save(createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong"));
@@ -226,7 +226,7 @@ class OauthServiceTest {
 
 	@DisplayName("제공되지 않은 provider로 소셜 로그인하여 회원가입을 할 수 없다")
 	@Test
-	public void signUpWithInvalidProvider() throws IOException {
+	void signUpWithInvalidProvider() throws IOException {
 		// given
 
 		List<Long> addressIds = getAddressIds(regionRepository.findAllByNameIn(List.of("서울 송파구 가락동")));
@@ -255,7 +255,7 @@ class OauthServiceTest {
 
 	@DisplayName("잘못된 인가 코드로 소셜 로그인하여 회원가입을 할 수 없다")
 	@Test
-	public void signUpWithInvalidCode() throws IOException {
+	void signUpWithInvalidCode() throws IOException {
 		// given
 		List<Long> addressIds = getAddressIds(regionRepository.findAllByNameIn(List.of("서울 송파구 가락동")));
 		Map<String, Object> requestBody = new HashMap<>();
@@ -294,7 +294,7 @@ class OauthServiceTest {
 
 	@DisplayName("로그인 아이디가 중복되는 경우 회원가입을 할 수 없다")
 	@Test
-	public void signUpWhenDuplicateLoginId() throws IOException {
+	void signUpWhenDuplicateLoginId() throws IOException {
 		// given
 		regionRepository.save(createRegion("서울 송파구 가락동"));
 		Member member = memberRepository.save(createMember("avatarUrlValue", "23Yong1234@gmail.com", "23Yong"));
@@ -347,7 +347,7 @@ class OauthServiceTest {
 
 	@DisplayName("로그인 아이디와 인가코드를 가지고 소셜 로그인을 한다")
 	@Test
-	public void login() throws JsonProcessingException {
+	void login() throws JsonProcessingException {
 		// given
 		Member member = new Member("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		memberRepository.save(member);
@@ -396,7 +396,7 @@ class OauthServiceTest {
 
 	@DisplayName("로그아웃을 수행한다")
 	@Test
-	public void logout() throws JsonProcessingException {
+	void logout() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		LocalDateTime now = createNow();
@@ -416,7 +416,7 @@ class OauthServiceTest {
 
 	@DisplayName("만료된 액세스 토큰을 가지고 로그아웃을 요청하면 블랙리스트에 추가하지 않는다")
 	@Test
-	public void logoutWithExpireAccessToken() throws JsonProcessingException {
+	void logoutWithExpireAccessToken() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		LocalDateTime now = LocalDateTime.now().minusDays(1);
@@ -436,7 +436,7 @@ class OauthServiceTest {
 
 	@DisplayName("만료된 리프레쉬 토큰을 가지고 로그아웃을 요청하면 이미 만료되어 아무 처리도 하지 않는다")
 	@Test
-	public void logoutWithExpireRefreshToken() throws JsonProcessingException {
+	void logoutWithExpireRefreshToken() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		LocalDateTime now = createNow().minusHours(10);
@@ -457,7 +457,7 @@ class OauthServiceTest {
 
 	@DisplayName("리프레쉬 토큰을 가지고 액세스 토큰을 갱신한다")
 	@Test
-	public void refreshAccessToken() throws JsonProcessingException {
+	void refreshAccessToken() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		LocalDateTime now = createNow();
@@ -484,7 +484,7 @@ class OauthServiceTest {
 
 	@DisplayName("유효하지 않은 토큰으로는 액세스 토큰을 갱신할 수 없다")
 	@Test
-	public void refreshAccessTokenWithInvalidRefreshToken() throws JsonProcessingException {
+	void refreshAccessTokenWithInvalidRefreshToken() throws JsonProcessingException {
 		// given
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");
 		LocalDateTime now = createNow();

--- a/backend/src/test/java/codesquard/app/api/oauth/properties/OauthPropertiesTest.java
+++ b/backend/src/test/java/codesquard/app/api/oauth/properties/OauthPropertiesTest.java
@@ -23,7 +23,7 @@ public class OauthPropertiesTest {
 
 	@DisplayName("provider가 주어지고 provider에 따른 oauth 설정값들을 OauthProvider가 가진다")
 	@Test
-	public void createOauthClientMap() {
+	void createOauthClientMap() {
 		// given
 		String provider = "naver";
 

--- a/backend/src/test/java/codesquard/app/api/redis/ItemViewRedisServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/redis/ItemViewRedisServiceTest.java
@@ -84,7 +84,7 @@ class ItemViewRedisServiceTest extends CacheTestSupport {
 
 	@DisplayName("회원이 두번째로 상품 상세 조회시 뷰 카운트는 증가하지 않는다")
 	@Test
-	public void addViewCount() {
+	void addViewCount() {
 		// given
 		Member member = MemberTestSupport.createMember("avatarUrl", "23Yong@gmail.com", "23Yong");
 		Principal principal = Principal.from(member);

--- a/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionRestControllerTest.java
@@ -36,7 +36,7 @@ class RegionRestControllerTest extends ControllerTestSupport {
 	private RegionService regionService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(regionRestController)
 			.setControllerAdvice(globalExceptionHandler)
 			.alwaysDo(print())
@@ -45,7 +45,7 @@ class RegionRestControllerTest extends ControllerTestSupport {
 
 	@DisplayName("동네(지역) 목록을 조회한다")
 	@Test
-	public void findAll() throws Exception {
+	void findAll() throws Exception {
 		// given
 		RegionItemResponse region1 = createRegionItemResponse("경기 부천시 괴안동");
 		RegionItemResponse region2 = createRegionItemResponse("경기 부천시 범박동");

--- a/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/region/RegionServiceTest.java
@@ -46,7 +46,7 @@ class RegionServiceTest {
 
 	@DisplayName("주소 목록을 처음 조회할때 10개가 조회한다")
 	@Test
-	public void findAllByRegionName() {
+	void findAllByRegionName() {
 		// given
 		regionRepository.saveAll(createFixedRegions());
 		int size = 10;

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemControllerTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemControllerTest.java
@@ -41,7 +41,7 @@ class WishItemControllerTest extends ControllerTestSupport {
 	private WishItemService wishItemService;
 
 	@BeforeEach
-	public void setup() {
+	void setup() {
 		mockMvc = MockMvcBuilders.standaloneSetup(wishItemController)
 			.setControllerAdvice(globalExceptionHandler)
 			.setCustomArgumentResolvers(authPrincipalArgumentResolver)
@@ -57,7 +57,7 @@ class WishItemControllerTest extends ControllerTestSupport {
 
 	@DisplayName("관심 상품들의 카테고리 목록을 요청한다")
 	@Test
-	public void readWishCategories() throws Exception {
+	void readWishCategories() throws Exception {
 		// given
 		WishCategoryListResponse response = WishCategoryListResponse.of(
 			List.of(findByName("스포츠/레저"), findByName("가구/인테리어")));

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
@@ -186,7 +186,7 @@ class WishItemServiceTest {
 
 	@DisplayName("한 회원이 등록한 관심 상품들의 중복되지 않은 카테고리를 조회한다")
 	@Test
-	public void readWishCategories() {
+	void readWishCategories() {
 		// given
 		List<Category> categories = categoryRepository.saveAll(List.of(findByName("스포츠/레저"), findByName("가구/인테리어")));
 		Category sport = categories.get(0);

--- a/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
+++ b/backend/src/test/java/codesquard/app/api/wishitem/WishItemServiceTest.java
@@ -143,7 +143,7 @@ class WishItemServiceTest {
 		// when
 		Long categoryId = null;
 		Long cursor = null;
-		ItemResponses responses = wishItemService.findAll(categoryId, 2, cursor);
+		ItemResponses responses = wishItemService.findAll(categoryId, 2, cursor, Principal.from(member));
 
 		// then
 		List<ItemResponse> contents = responses.getContents();
@@ -178,7 +178,7 @@ class WishItemServiceTest {
 		wishItemService.changeWishStatus(item3.getId(), member.getId(), WishStatus.YES);
 
 		// when
-		ItemResponses responses = wishItemService.findAll(category1.getId(), 10, null);
+		ItemResponses responses = wishItemService.findAll(category1.getId(), 10, null, Principal.from(member));
 
 		// then
 		assertThat(responses.getContents()).hasSize(2);

--- a/backend/src/test/java/codesquard/app/domain/jwt/JwtProviderTest.java
+++ b/backend/src/test/java/codesquard/app/domain/jwt/JwtProviderTest.java
@@ -26,7 +26,7 @@ class JwtProviderTest {
 
 	@DisplayName("해시맵을 기반으로 JWT 객체를 생성한다")
 	@Test
-	public void createJwtBasedOnAuthenticateMember() {
+	void createJwtBasedOnAuthenticateMember() {
 		// given
 		JwtProvider jwtProvider = new JwtProvider(jwtProperties);
 		Member member = createMember("avatarUrlValue", "23Yong@gmail.com", "23Yong");

--- a/backend/src/test/java/codesquard/app/domain/member/AuthenticateMemberTest.java
+++ b/backend/src/test/java/codesquard/app/domain/member/AuthenticateMemberTest.java
@@ -11,7 +11,7 @@ class AuthenticateMemberTest {
 
 	@DisplayName("Member 엔티티를 가지고 AuthenticateUser 객체를 생성한다")
 	@Test
-	public void from() {
+	void from() {
 		// given
 		Member member = new Member("avatarUrlValue", "23Yong1234@gmail.com", "23Yong");
 

--- a/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
@@ -9,7 +9,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
 
-import codesquard.app.api.errors.errorcode.ErrorCode;
+import codesquard.app.api.errors.errorcode.MemberErrorCode;
+import codesquard.app.api.errors.errorcode.OauthErrorCode;
 import codesquard.app.api.errors.exception.NotFoundResourceException;
 import codesquard.app.api.errors.exception.UnAuthorizationException;
 
@@ -35,7 +36,7 @@ class MemberRepositoryTest {
 
 		// when
 		Member findMember = memberRepository.findMemberByLoginId(loginId)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 
 		// then
 		assertThat(member.getLoginId()).isEqualTo(findMember.getLoginId());
@@ -81,7 +82,7 @@ class MemberRepositoryTest {
 
 		// when
 		Member findMember = memberRepository.findMemberByLoginIdAndEmail(loginId, email)
-			.orElseThrow(() -> new UnAuthorizationException(ErrorCode.FAIL_LOGIN));
+			.orElseThrow(() -> new UnAuthorizationException(OauthErrorCode.FAIL_LOGIN));
 
 		// then
 		assertThat(findMember)
@@ -115,7 +116,7 @@ class MemberRepositoryTest {
 
 		// when
 		Member findMember = memberRepository.findMemberByEmail(email)
-			.orElseThrow(() -> new NotFoundResourceException(ErrorCode.NOT_FOUND_MEMBER));
+			.orElseThrow(() -> new NotFoundResourceException(MemberErrorCode.NOT_FOUND_MEMBER));
 
 		// thenR
 		assertThat(findMember).isNotNull();

--- a/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/member/MemberRepositoryTest.java
@@ -28,7 +28,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("로그인 아이디를 가지고 회원을 조회할 수 있다")
 	@Test
-	public void findMemberByLoginId() {
+	void findMemberByLoginId() {
 		// given
 		Member member = new Member("avatarUrl", "23Yong@gmail.com", "23Yong");
 		memberRepository.save(member);
@@ -44,7 +44,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("로그인 아이디를 가지고 회원을 조회할때 해당하는 회원이 없는 경우 null을 반환한다")
 	@Test
-	public void findMemberByLoginIdWhenMemberIsNotExist() {
+	void findMemberByLoginIdWhenMemberIsNotExist() {
 		// given
 		String loginId = "23Yong";
 
@@ -58,7 +58,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("닉네임을 가지고 회원이 존재하는지 확인한다")
 	@Test
-	public void existsMemberByLoginId() {
+	void existsMemberByLoginId() {
 		// given
 		Member member = new Member("avatarUrl", "23Yong@gmail.com", "23Yong");
 		memberRepository.save(member);
@@ -73,7 +73,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("로그인 아이디와 이메일을 가지고 회원을 조회한다")
 	@Test
-	public void findMemberByLoginIdAndAndEmail() {
+	void findMemberByLoginIdAndAndEmail() {
 		// given
 		String loginId = "23Yong";
 		String email = "23Yong1234@gmail.com";
@@ -92,7 +92,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("로그인 아이디와 이메일을 가지고 회원을 조회할때 회원이 없는 경우 null을 반환한다")
 	@Test
-	public void findMemberByLoginIdAndAndEmailWhenMemberIsNotExist() {
+	void findMemberByLoginIdAndAndEmailWhenMemberIsNotExist() {
 		// given
 		String loginId = "23Yong";
 		String email = "23Yong1234@gmail.com";
@@ -107,7 +107,7 @@ class MemberRepositoryTest {
 
 	@DisplayName("이메일을 가지고 회원을 조회한다")
 	@Test
-	public void findMemberByEmail() {
+	void findMemberByEmail() {
 		// given
 		String email = "23Yong@gmail.com";
 		String loginId = "23Yong";

--- a/backend/src/test/java/codesquard/app/domain/oauth/InMemoryOauthClientRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/oauth/InMemoryOauthClientRepositoryTest.java
@@ -21,7 +21,7 @@ class InMemoryOauthClientRepositoryTest {
 
 	@DisplayName("provider가 주어지고 provider에 따른 OauthProvider를 조회하고 oauth 설정들을 가진다")
 	@Test
-	public void findByProviderName() {
+	void findByProviderName() {
 		// given
 		String provider = "naver";
 

--- a/backend/src/test/java/codesquard/app/domain/region/RegionSliceRepositoryTest.java
+++ b/backend/src/test/java/codesquard/app/domain/region/RegionSliceRepositoryTest.java
@@ -28,7 +28,7 @@ class RegionSliceRepositoryTest {
 
 	@DisplayName("아무 조건없이 모든 동네중 10개를 조회한다")
 	@Test
-	public void searchBySlice() {
+	void searchBySlice() {
 		// given
 		List<Region> regions = RegionTestSupport.createFixedRegions();
 		regionRepository.saveAll(regions);
@@ -49,7 +49,7 @@ class RegionSliceRepositoryTest {
 
 	@DisplayName("첫 동네 조회 이후 5칸 스크롤하여 다음 페이지의 동네를 조회한다")
 	@Test
-	public void searchBySliceWithScrollToNextPage() {
+	void searchBySliceWithScrollToNextPage() {
 		// given
 		List<Region> regions = RegionTestSupport.createFixedRegions();
 		regionRepository.saveAll(regions);
@@ -74,7 +74,7 @@ class RegionSliceRepositoryTest {
 
 	@DisplayName("동네 이름에 '부천시'가 들어간 조회 이후 5칸 만큼 스크롤한다")
 	@Test
-	public void searchBySliceRegionNameWithScrollToNextPage() {
+	void searchBySliceRegionNameWithScrollToNextPage() {
 		// given
 		List<Region> regions = RegionTestSupport.createFixedRegions();
 		regionRepository.saveAll(regions);


### PR DESCRIPTION
## 구현한 것

- API 응답의 성공 메시지를 도메인별로 분리
- 채팅방 mapper 메소드에서 chatLog가 존재하지 않을 시 null을 바로 반환하도록 개선
- ErrorCode를 도메인별 ErrorCode로 분리
- wishRepository에서 deleteByItem를 deleteAllByIdIn로 개선
- 불필요한 코드 및 클래스 제거
- 테스트 코드에서 각각의 테스트에 public 접근 제한자를 제거